### PR TITLE
multi-select with cmd-click on mac

### DIFF
--- a/src/utils/Select.js
+++ b/src/utils/Select.js
@@ -70,7 +70,7 @@ function clickHandler (evt) {
   if (this.tagName === 'use') {
     if ($(this).parents('.selected').length === 0) {
       let selection = [this];
-      if (evt.ctrlKey) {
+      if (window.navigator.oscpu.match(/Mac/) ? evt.metaKey : evt.ctrlKey) {
         selection = selection.concat(Array.from(document.getElementsByClassName('selected')));
       }
       selectAll(selection, neonView, info, dragHandler);


### PR DESCRIPTION
Check to see if navigator.oscpu contains "Mac". If it does, check for
cmd being pressed. Otherwise use ctrl. Resolves #381.