### PR TITLE
Put Verovio into a web worker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js: 10
+env:
+  - NODE_OPTIONS=--max_old_space_size=2048
 os: osx
 osx_image: xcode10.2
 if: (branch = master OR branch = develop)

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
             "<rootDir>/node_modules/"
         ],
         "moduleNameMapper": {
-            "Validation": "<rootDir>/test/SubstituteValidation.js"
+            "Validation": "<rootDir>/test/SubstituteValidation.js",
+            "VerovioWrapper": "<rootDir>/test/VerovioWrapper.js"
         }
     },
     "babel": {

--- a/src/NeonCore.js
+++ b/src/NeonCore.js
@@ -146,11 +146,10 @@ class NeonCore {
    */
   loadPage (pageURI) {
     return new Promise((resolve, reject) => {
-      if (this.lastPageLoaded === pageURI) {
+      if (this.lastPageLoaded === pageURI && this.neonCache.has(pageURI)) {
         resolve(this.neonCache.get(pageURI));
       } else if (this.neonCache.has(pageURI)) {
         this.loadData(pageURI, this.neonCache.get(pageURI).mei).then(() => {
-          this.lastPageLoaded = pageURI;
           resolve(this.neonCache.get(pageURI));
         });
       } else if (this.blankPages.includes(pageURI)) {
@@ -172,7 +171,6 @@ class NeonCore {
             }
           }).then(data => {
             this.loadData(pageURI, data).then(() => {
-              this.lastPageLoaded = pageURI;
               resolve(this.neonCache.get(pageURI));
             });
           }).catch(err => {
@@ -195,6 +193,7 @@ class NeonCore {
    */
   loadData (pageURI, data, dirty = false) {
     Validation.sendForValidation(data);
+    this.lastPageLoaded = pageURI;
     return new Promise((resolve, reject) => {
       let message = {
         id: uuid(),

--- a/src/NeonCore.js
+++ b/src/NeonCore.js
@@ -1,5 +1,5 @@
 import * as Validation from './Validation.js';
-import VerovioWorker from './VerovioWorker.js';
+import VerovioWrapper from './VerovioWrapper.js';
 import PouchDb from 'pouchdb';
 const uuid = require('uuid/v4');
 
@@ -14,7 +14,7 @@ class NeonCore {
    * @returns {object} A NeonCore object.
    */
   constructor (manifest) {
-    this.verovioWorker = new VerovioWorker();
+    this.verovioWrapper = new VerovioWrapper();
     Validation.init();
 
     /**
@@ -215,8 +215,8 @@ class NeonCore {
           resolve();
         }
       }
-      this.verovioWorker.addEventListener('message', handle.bind(this));
-      this.verovioWorker.postMessage(message);
+      this.verovioWrapper.addEventListener('message', handle.bind(this));
+      this.verovioWrapper.postMessage(message);
     });
   }
 
@@ -260,13 +260,13 @@ class NeonCore {
           action: 'getElementAttr',
           elementId: elementId
         };
-        this.verovioWorker.addEventListener('message', function handle (evt) {
+        this.verovioWrapper.addEventListener('message', function handle (evt) {
           if (evt.data.id === message.id) {
             evt.target.removeEventListener('message', handle);
             resolve(evt.data.attributes);
           }
         });
-        this.verovioWorker.postMessage(message);
+        this.verovioWrapper.postMessage(message);
       });
     });
   }
@@ -309,8 +309,8 @@ class NeonCore {
             }
           }
         }
-        this.verovioWorker.addEventListener('message', handle.bind(this));
-        this.verovioWorker.postMessage(message);
+        this.verovioWrapper.addEventListener('message', handle.bind(this));
+        this.verovioWrapper.postMessage(message);
       });
     });
   }
@@ -330,28 +330,28 @@ class NeonCore {
           id: uuid(),
           action: 'getMEI'
         };
-        this.verovioWorker.addEventListener('message', function handle (evt) {
+        this.verovioWrapper.addEventListener('message', function handle (evt) {
           if (evt.data.id === message.id) {
             mei = evt.data.mei;
             evt.target.removeEventListener('message', handle);
             resolve();
           }
         });
-        this.verovioWorker.postMessage(message);
+        this.verovioWrapper.postMessage(message);
       });
       let svgPromise = new Promise((resolve, reject) => {
         let message = {
           id: uuid(),
           action: 'renderToSVG'
         };
-        this.verovioWorker.addEventListener('message', function handle (evt) {
+        this.verovioWrapper.addEventListener('message', function handle (evt) {
           if (evt.data.id === message.id) {
             svgText = evt.data.svg;
             evt.target.removeEventListener('message', handle);
             resolve();
           }
         });
-        this.verovioWorker.postMessage(message);
+        this.verovioWrapper.postMessage(message);
       });
 
       meiPromise.then(() => { return svgPromise; }).then(() => {
@@ -386,13 +386,13 @@ class NeonCore {
           id: uuid(),
           action: 'editInfo'
         };
-        this.verovioWorker.addEventListener('message', function handle (evt) {
+        this.verovioWrapper.addEventListener('message', function handle (evt) {
           if (evt.data.id === message.id) {
             evt.target.removeEventListener('message', handle);
             resolve(evt.data.info);
           }
         });
-        this.verovioWorker.postMessage(message);
+        this.verovioWrapper.postMessage(message);
       });
     });
   }

--- a/src/NeonCore.js
+++ b/src/NeonCore.js
@@ -150,6 +150,7 @@ class NeonCore {
         resolve(this.neonCache.get(pageURI));
       } else if (this.neonCache.has(pageURI)) {
         this.loadData(pageURI, this.neonCache.get(pageURI).mei).then(() => {
+          this.lastPageLoaded = pageURI;
           resolve(this.neonCache.get(pageURI));
         });
       } else if (this.blankPages.includes(pageURI)) {

--- a/src/NeonView.js
+++ b/src/NeonView.js
@@ -85,6 +85,8 @@ class NeonView {
    * Redo an action performed on the current page (if any)
    */
   redo () {
+    // let val = await this.core.redo(this.view.getCurrentPageURI());
+    // return val;
     return this.core.redo(this.view.getCurrentPageURI());
   }
 
@@ -92,6 +94,8 @@ class NeonView {
    * Undo the last action performed on the current page (if any)
    */
   undo () {
+    // let val = await this.core.undo(this.view.getCurrentPageURI());
+    // return val;
     return this.core.undo(this.view.getCurrentPageURI());
   }
 
@@ -118,10 +122,7 @@ class NeonView {
    * @returns {Promise} A promise that resolves to the result of the action.
    */
   edit (action, pageURI) {
-    let editPromise = new Promise((resolve) => {
-      resolve(this.core.edit(action, pageURI));
-    });
-    return editPromise;
+    return this.core.edit(action, pageURI);
   }
 
   /**
@@ -131,10 +132,7 @@ class NeonView {
    * @returns {Promise} A promise that resolves to the available attributes.
    */
   getElementAttr (elementID, pageURI) {
-    let elementPromise = new Promise((resolve, reject) => {
-      resolve(this.core.getElementAttr(elementID, pageURI));
-    });
-    return elementPromise;
+    return this.core.getElementAttr(elementID, pageURI);
   }
 
   /**

--- a/src/VerovioWorker.js
+++ b/src/VerovioWorker.js
@@ -1,0 +1,47 @@
+const verovio = require('verovio-dev');
+
+var toolkit = new verovio.toolkit();
+toolkit.setOptions({
+  format: 'mei',
+  noFooter: 1,
+  noHeader: 1,
+  pageMarginLeft: 0,
+  pageMarginTop: 0,
+  font: 'Bravura',
+  useFacsimile: true,
+  createDefaultSyl: true,
+  createDefaultSylBBox: true
+});
+
+onmessage = handleNeonEvent;
+
+function handleNeonEvent (evt) {
+  let data = evt.data;
+  let result = {
+    id: data.id
+  };
+
+  switch (data.action) {
+    case 'renderData':
+      result.svg = toolkit.renderData(data.mei, {});
+      break;
+    case 'getElementAttr':
+      result.attributes = toolkit.getElementAttr(data.elementId);
+      break;
+    case 'edit':
+      result.result = toolkit.edit(data.editorAction);
+      break;
+    case 'getMEI':
+      result.mei = toolkit.getMEI(0, true);
+      break;
+    case 'editInfo':
+      result.info = toolkit.editInfo();
+      break;
+    case 'renderToSVG':
+      result.svg = toolkit.renderToSVG(1);
+      break;
+    default:
+      break;
+  }
+  postMessage(result);
+}

--- a/src/VerovioWrapper.js
+++ b/src/VerovioWrapper.js
@@ -1,0 +1,15 @@
+import VerovioWorker from './VerovioWorker.js';
+
+export default class VerovioWrapper {
+  constructor () {
+    this.verovioWorker = new VerovioWorker();
+  }
+
+  addEventListener (type, handler) {
+    return this.verovioWorker.addEventListener(type, handler);
+  }
+
+  postMessage (message) {
+    return this.verovioWorker.postMessage(message);
+  }
+}

--- a/src/utils/EditControls.js
+++ b/src/utils/EditControls.js
@@ -109,18 +109,24 @@ export function initUndoRedoPanel (neonView) {
   });
 
   function undoHandler () {
-    if (!neonView.undo(neonView.view.getCurrentPageURI())) {
-      console.error('Failed to undo action.');
-    } else {
-      neonView.updateForCurrentPage();
-    }
+    neonView.undo(neonView.view.getCurrentPageURI()).then(result => {
+      if (result) {
+        console.debug('Success');
+        neonView.updateForCurrentPage();
+      } else {
+        console.error('Failed to undo action');
+      }
+    });
   }
 
   function redoHandler () {
-    if (!neonView.redo(neonView.view.getCurrentPageURI())) {
-      console.error('Failed to redo action');
-    } else {
-      neonView.updateForCurrentPage();
-    }
+    neonView.redo(neonView.view.getCurrentPageURI()).then(result => {
+      if (result) {
+        console.debug('Success');
+        neonView.updateForCurrentPage();
+      } else {
+        console.error('Failed to redo action');
+      }
+    });
   }
 }

--- a/test/NeonCore.test.js
+++ b/test/NeonCore.test.js
@@ -464,7 +464,7 @@ test('Test chain action', async () => {
   };
   expect(await neon.edit(editorAction, pathToPNG)).toBeTruthy();
   let dragAtts = await neon.getElementAttr('m-5ba56425-5c59-4f34-9e56-b86779cb4d6d', pathToPNG);
-  let insertAtts = await neon.getElementAttr(JSON.parse(neon.info(pathToPNG))[1], pathToPNG);
+  let insertAtts = await neon.getElementAttr(JSON.parse(await neon.info(pathToPNG))[1], pathToPNG);
   expect(dragAtts.pname).toBe('b');
   expect(dragAtts.oct).toBe('2');
   expect(insertAtts.pname).toBe('e');

--- a/test/SinglePageBrowser.test.js
+++ b/test/SinglePageBrowser.test.js
@@ -10,7 +10,7 @@ const error = require('selenium-webdriver/lib/error');
 const firefox = require('selenium-webdriver/firefox');
 const chrome = require('selenium-webdriver/chrome');
 
-jest.setTimeout('15000');
+jest.setTimeout('20000');
 
 beforeAll(async () => {
   // Link test MEI/png to public/uploads so we can use them

--- a/test/SinglePageBrowser.test.js
+++ b/test/SinglePageBrowser.test.js
@@ -288,6 +288,7 @@ describe.each(['firefox', 'chrome', 'safari'])('Tests on %s', (title) => {
           expect(buttonClass).toContain('is-active');
           // await browser.actions().move({ origin: someNc, x: 100, y: 100 }).click().perform();
           await browser.executeScript(() => { document.getElementById('svg_group').dispatchEvent(new window.MouseEvent('click', { bubbles: true })); });
+          await browser.wait(until.stalenessOf(someNc), 1000);
           let newNcCount = (await browser.findElements(By.className('nc'))).length;
           expect(newNcCount).toBe(ncCount + 1);
         });

--- a/test/SinglePageBrowser.test.js
+++ b/test/SinglePageBrowser.test.js
@@ -259,12 +259,16 @@ describe.each(['firefox', 'chrome', 'safari'])('Tests on %s', (title) => {
       test('Undo/Redo', async () => {
         let undoButton = await browser.findElement(By.id('undo'));
         const actions = browser.actions();
+        let element = await browser.findElement(By.className('nc'));
         let origCount = (await browser.findElements(By.className('nc'))).length;
         await actions.click(undoButton).perform();
+        await browser.wait(until.stalenessOf(element), 1000);
         let newCount = (await browser.findElements(By.className('nc'))).length;
         expect(newCount).toBeGreaterThan(origCount);
+        element = browser.findElement(By.className('nc'));
         // await actions.click(redoButton).perform();
         await browser.executeScript(() => { document.getElementById('redo').dispatchEvent(new window.Event('click')); });
+        await browser.wait(until.stalenessOf(element), 1000);
         newCount = (await browser.findElements(By.className('nc'))).length;
         expect(newCount).toEqual(origCount);
       });

--- a/test/SinglePageBrowser.test.js
+++ b/test/SinglePageBrowser.test.js
@@ -252,6 +252,7 @@ describe.each(['firefox', 'chrome', 'safari'])('Tests on %s', (title) => {
         await browser.executeScript((id) => { document.getElementById(id).children[0].dispatchEvent(new window.Event('mousedown')); }, id);
         let deleteButton = await browser.findElement(By.id('delete'));
         await actions.click(deleteButton).perform();
+        await browser.wait(until.stalenessOf(syl), 1000);
         return expect(browser.findElement(By.id(id))).rejects.toThrowError(error.NoSuchElementError);
       });
 

--- a/test/SinglePageBrowser.test.js
+++ b/test/SinglePageBrowser.test.js
@@ -56,7 +56,7 @@ describe.each(['firefox', 'chrome', 'safari'])('Tests on %s', (title) => {
       await browser.wait(until.elementLocated(By.id(neumeID)), 2000); // Wait two seconds for elements to appear
       await browser.executeScript((neumeID) => { document.getElementById(neumeID).dispatchEvent(new window.Event('mouseover')); }, neumeID);
       let body = await browser.findElement(By.className('message-body'));
-      await browser.wait(until.elementIsVisible(body), 1000);
+      await browser.wait(until.elementIsVisible(body), 2000);
       message = await body.getText();
 
       expect(message).toContain('Clivis');

--- a/test/SinglePageBrowser.test.js
+++ b/test/SinglePageBrowser.test.js
@@ -53,10 +53,10 @@ describe.each(['firefox', 'chrome', 'safari'])('Tests on %s', (title) => {
     test('Check Info Box Neumes', async () => {
       let neumeID = 'm-07ad2140-4fa1-45d4-af47-6733add00825';
       var message;
-      await browser.wait(until.elementLocated(By.id(neumeID)), 2000); // Wait two seconds for elements to appear
+      await browser.wait(until.elementLocated(By.id(neumeID)), 5000); // Wait two seconds for elements to appear
       await browser.executeScript((neumeID) => { document.getElementById(neumeID).dispatchEvent(new window.Event('mouseover')); }, neumeID);
       let body = await browser.findElement(By.className('message-body'));
-      await browser.wait(until.elementIsVisible(body), 2000);
+      await browser.wait(until.elementIsVisible(body), 5000);
       message = await body.getText();
 
       expect(message).toContain('Clivis');
@@ -65,10 +65,10 @@ describe.each(['firefox', 'chrome', 'safari'])('Tests on %s', (title) => {
 
     test('Check Info Box Clef', async () => {
       let clefId = 'm-45439068-5e0c-4595-a820-4faa16771422';
-      await browser.wait(until.elementLocated(By.id(clefId)), 2000);
+      await browser.wait(until.elementLocated(By.id(clefId)), 5000);
       await browser.executeScript((id) => { document.getElementById(id).dispatchEvent(new window.Event('mouseover')); }, clefId);
       var notification = await browser.findElement(By.className('message'));
-      await browser.wait(until.elementTextMatches(notification, /clef/), 1000);
+      await browser.wait(until.elementTextMatches(notification, /clef/), 5000);
       var message = await browser.findElement(By.className('message-body')).getText();
       expect(message).toContain('Shape: C');
       expect(message).toContain('Line: 3');
@@ -262,13 +262,13 @@ describe.each(['firefox', 'chrome', 'safari'])('Tests on %s', (title) => {
         let element = await browser.findElement(By.className('nc'));
         let origCount = (await browser.findElements(By.className('nc'))).length;
         await actions.click(undoButton).perform();
-        await browser.wait(until.stalenessOf(element), 1000);
+        await browser.wait(until.stalenessOf(element), 5000);
         let newCount = (await browser.findElements(By.className('nc'))).length;
         expect(newCount).toBeGreaterThan(origCount);
         element = browser.findElement(By.className('nc'));
         // await actions.click(redoButton).perform();
         await browser.executeScript(() => { document.getElementById('redo').dispatchEvent(new window.Event('click')); });
-        await browser.wait(until.stalenessOf(element), 1000);
+        await browser.wait(until.stalenessOf(element), 5000);
         newCount = (await browser.findElements(By.className('nc'))).length;
         expect(newCount).toEqual(origCount);
       });
@@ -288,7 +288,7 @@ describe.each(['firefox', 'chrome', 'safari'])('Tests on %s', (title) => {
           expect(buttonClass).toContain('is-active');
           // await browser.actions().move({ origin: someNc, x: 100, y: 100 }).click().perform();
           await browser.executeScript(() => { document.getElementById('svg_group').dispatchEvent(new window.MouseEvent('click', { bubbles: true })); });
-          await browser.wait(until.stalenessOf(someNc), 1000);
+          await browser.wait(until.stalenessOf(someNc), 5000);
           let newNcCount = (await browser.findElements(By.className('nc'))).length;
           expect(newNcCount).toBe(ncCount + 1);
         });

--- a/test/SinglePageBrowser.test.js
+++ b/test/SinglePageBrowser.test.js
@@ -55,7 +55,9 @@ describe.each(['firefox', 'chrome', 'safari'])('Tests on %s', (title) => {
       var message;
       await browser.wait(until.elementLocated(By.id(neumeID)), 2000); // Wait two seconds for elements to appear
       await browser.executeScript((neumeID) => { document.getElementById(neumeID).dispatchEvent(new window.Event('mouseover')); }, neumeID);
-      message = await browser.findElement(By.className('message-body')).getText();
+      let body = await browser.findElement(By.className('message-body'));
+      await browser.wait(until.elementIsVisible(body), 1000);
+      message = await body.getText();
 
       expect(message).toContain('Clivis');
       expect(message).toContain('A2 G2');
@@ -66,8 +68,8 @@ describe.each(['firefox', 'chrome', 'safari'])('Tests on %s', (title) => {
       await browser.wait(until.elementLocated(By.id(clefId)), 2000);
       await browser.executeScript((id) => { document.getElementById(id).dispatchEvent(new window.Event('mouseover')); }, clefId);
       var notification = await browser.findElement(By.className('message'));
-      await browser.wait(until.elementIsVisible(notification));
-      var message = await browser.findElement(By.className('message')).getText();
+      await browser.wait(until.elementTextMatches(notification, /clef/), 1000);
+      var message = await browser.findElement(By.className('message-body')).getText();
       expect(message).toContain('Shape: C');
       expect(message).toContain('Line: 3');
     });

--- a/test/VerovioWrapper.js
+++ b/test/VerovioWrapper.js
@@ -1,0 +1,65 @@
+const verovio = require('verovio-dev');
+
+export default class VerovioWrapper {
+  constructor () {
+    this.toolkit = new verovio.toolkit();
+    this.toolkit.setOptions({
+      format: 'mei',
+      noFooter: 1,
+      noHeader: 1,
+      pageMarginLeft: 0,
+      pageMarginTop: 0,
+      font: 'Bravura',
+      useFacsimile: true,
+      createDefaultSyl: true,
+      createDefaultSylBBox: true
+    });
+  }
+
+  addEventListener (type, handler) {
+    this.handler = handler;
+  }
+
+  postMessage (message) {
+    let data = this.handleNeonEvent(message);
+    let evt = {
+      data: data,
+      target: {
+        removeEventListener: () => {}
+      }
+    };
+
+    this.handler(evt);
+  }
+
+  handleNeonEvent (data) {
+    let result = {
+      id: data.id
+    };
+
+    switch (data.action) {
+      case 'renderData':
+        result.svg = this.toolkit.renderData(data.mei, {});
+        break;
+      case 'getElementAttr':
+        result.attributes = this.toolkit.getElementAttr(data.elementId);
+        break;
+      case 'edit':
+        result.result = this.toolkit.edit(data.editorAction);
+        break;
+      case 'getMEI':
+        result.mei = this.toolkit.getMEI(0, true);
+        break;
+      case 'editInfo':
+        result.info = this.toolkit.editInfo();
+        break;
+      case 'renderToSVG':
+        result.svg = this.toolkit.renderToSVG(1);
+        break;
+      default:
+        break;
+    }
+
+    return result;
+  }
+}


### PR DESCRIPTION
Move verovio into a web worker. `src/VerovioWorker.js` is the worker itself. `src/VerovioWrapper.js` exists as a buffer so we can cleanly mock this entire part for testing in jest.

Resolve #346.