### PR TITLE
prevent selection of neume elements while in selectByBBox mode

### DIFF
--- a/src/utils/Select.js
+++ b/src/utils/Select.js
@@ -65,7 +65,7 @@ function clickHandler (evt) {
   // If in insert mode or panning is active from shift key
   if (mode === 'insert' || evt.shiftKey) { return; }
   // Check if the element being clicked on is part of a drag Selection
-  if (this.tagName === 'use') {
+  if (this.tagName === 'use' && getSelectionType() !== 'selByBBox') {
     if ($(this).parents('.selected').length === 0) {
       let selection = [this];
       if (window.navigator.userAgent.match(/Mac/) ? evt.metaKey : evt.ctrlKey) {


### PR DESCRIPTION
Require selection mode to not be bbox in order to select anything with a use tag (including custos and clefs). Resolves #417