### PR TITLE
Allow upload of single single pages on GH pages without a manifest

### DIFF
--- a/pages/editor.js
+++ b/pages/editor.js
@@ -8,6 +8,8 @@ import InfoModule from '../src/InfoModule';
 import TextView from '../src/TextView';
 import TextEditMode from '../src/TextEditMode';
 
+import PouchDB from 'pouchdb';
+
 let name = getGetParam('manifest');
 let manifestLocation = 'manifests/' + name + '.jsonld';
 let storage = getGetParam('storage');
@@ -48,7 +50,7 @@ if (name) {
     view.start();
   });
 } else {
-  let db = new PouchDb('Neon-User-Storage');
+  let db = new PouchDB('Neon-User-Storage');
   db.getAttachment(storage, 'manifest').then(blob => {
     return new window.Response(blob).json();
   }).then(async manifest => {

--- a/pages/static/index.html
+++ b/pages/static/index.html
@@ -5,7 +5,7 @@
     <script src="./pretty.js"></script>
     <script src="//cdn.jsdelivr.net/npm/pouchdb@7.0.0/dist/pouchdb.min.js"></script>
   </head>
-  <body>
+  <body style="overflow: auto;">
     <form action="./editor.html" id="page-form" method="get" style="margin:5% auto 0;width: 15em;">
       <div class="field">
         <label for="page-selector" class="label">Select a Page:&nbsp;</label>
@@ -44,6 +44,22 @@
       <div class="control">
         <button type="submit" class="button">Load</button>
         <button type="button" class="button" id="remove-button">Remove</button>
+      </div>
+    </form>
+
+    <form id="generate-storage-form" style="margin: 5% auto 0; width: 15em;">
+      <div class="field">
+        <label class="label" for="upload-mei">Add MEI Neume File:&nbsp;</label>
+        <div class="select">
+          <input type="file" required accept="application/mei+xml" id="upload-mei">
+        </div>
+        <label class="label" for="upload-bg">Add Background Image:&nbsp;</label>
+        <div class="select">
+          <input type="file" required accept="image/png, image/jpeg" id="upload-bg">
+        </div>
+      </div>
+      <div class="control">
+        <button type="submit" class="button">Upload and Generate Manifest</button>
       </div>
     </form>
 

--- a/pages/static/storage.js
+++ b/pages/static/storage.js
@@ -1,5 +1,38 @@
 const db = new PouchDB('Neon-User-Storage');
 
+function uint8ToUuid(data) {
+  if (data.length !== 16) {
+    return '';
+  }
+  function cb(previous, current) {
+    return previous + current.toString(16).padStart(2, '0');
+  }
+  return data.slice(0, 4).reduce(cb, '') +
+        '-' + data.slice(4, 6).reduce(cb, '') +
+        '-' + data.slice(6, 8).reduce(cb, '') +
+        '-' + data.slice(8, 10).reduce(cb, '') +
+        '-' + data.slice(10).reduce(cb, '');
+}
+function uuidv4() {
+  // Check for crypto API
+  if (window.crypto === undefined) {
+    return uint8ToUuid(new Uint8Array(16));
+  }
+  // Get 16 octets for UUID
+  const octets = new Uint8Array(16);
+  const modifiers = Uint8Array.from([
+    parseInt('01000000', 2),
+    parseInt('10000000', 2),
+    parseInt('00001111', 2),
+    parseInt('00111111', 2) // Mask to zero higher bits, variant
+  ]);
+  window.crypto.getRandomValues(octets);
+  // Set version bits and variant bits
+  octets[6] = (octets[6] & modifiers[2]) | modifiers[0];
+  octets[8] = (octets[8] & modifiers[3]) | modifiers[1];
+  return uint8ToUuid(octets);
+}
+
 getAllDocuments().then(response => {
   const storage = document.getElementById('storage-selector');
   for (const doc of response.rows) {
@@ -82,7 +115,7 @@ function createManifest (mei, bg) {
         }
       }
     ],
-    '@id': 'test-id',
+    '@id': uuidv4(),
     'title': mei.name,
     'timestamp': (new Date()).toISOString()
   };
@@ -110,7 +143,7 @@ function createManifest (mei, bg) {
       manifest['image'] = bgUri;
       manifest['mei_annotations'] = [
         {
-          'id': 'test-id-2',
+          'id': uuidv4(),
           'type': 'Annotation',
           'body': meiUri,
           'target': bgUri

--- a/src/utils/random.ts
+++ b/src/utils/random.ts
@@ -1,0 +1,37 @@
+function uint8ToUuid (data: Uint8Array): string {
+  if (data.length !== 16) {
+    return '';
+  }
+
+  function cb (previous: string, current: number): string {
+    return previous + current.toString(16).padStart(2, '0');
+  }
+
+  return data.slice(0, 4).reduce(cb, '') +
+    '-' + data.slice(4, 6).reduce(cb, '') +
+    '-' + data.slice(6, 8).reduce(cb, '') +
+    '-' + data.slice(8, 10).reduce(cb, '') +
+    '-' + data.slice(10).reduce(cb, '');
+}
+
+export function uuidv4 (): string {
+  // Check for crypto API
+  if (window.crypto === undefined) {
+    return uint8ToUuid(new Uint8Array(16));
+  }
+
+  // Get 16 octets for UUID
+  const octets = new Uint8Array(16);
+  const modifiers = Uint8Array.from([
+    parseInt('01000000', 2),  // Version bits (4 => 0100)
+    parseInt('10000000', 2),  // Variant bits (10x)
+    parseInt('00001111', 2),  // Mask to zero higher bits, version
+    parseInt('00111111', 2)   // Mask to zero higher bits, variant
+  ]);
+  window.crypto.getRandomValues(octets);
+  // Set version bits and variant bits
+  octets[6] = (octets[6] & modifiers[2]) | modifiers[0];
+  octets[8] = (octets[8] & modifiers[3]) | modifiers[1];
+
+  return uint8ToUuid(octets);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "outDir": "./build",
         "allowJs": true,
-        "target": "es2016",
+        "target": "es2017",
         "sourceMap": true,
         "module": "commonjs",
         "allowSyntheticDefaultImports": true


### PR DESCRIPTION
Permits a user to select an MEI file and background image (JPEG or PNG) and generates a manifest with these files encoded as data URIs. UUIDs are generated using functions written in `src/utils/random.ts` that are compiled to JavaScript and added to `storage.js`. These functions work and generate valid version 4 UUIDs.

ES2017 is used as a target to give access to `String.prototype.padStart`. The [Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Crypto) is used to generate the random values used in the UUIDs.

Resolves #532.