### PR TITLE
Feature/external context 538

### DIFF
--- a/pages/generate-index
+++ b/pages/generate-index
@@ -1,5 +1,6 @@
 #!/bin/bash
-context="[\"http://www.w3.org/ns/anno.jsonld\",{\"schema\":\"http://schema.org/\",\"title\":\"schema:name\",\"timestamp\":\"schema:dateModified\",\"image\":{\"@id\":\"schema:image\",\"@type\":\"@id\"},\"mei_annotations\":{\"@id\":\"Annotation\",\"@type\":\"@id\",\"@container\":\"@list\"}}]"
+# context="[\"http://www.w3.org/ns/anno.jsonld\",{\"schema\":\"http://schema.org/\",\"title\":\"schema:name\",\"timestamp\":\"schema:dateModified\",\"image\":{\"@id\":\"schema:image\",\"@type\":\"@id\"},\"mei_annotations\":{\"@id\":\"Annotation\",\"@type\":\"@id\",\"@container\":\"@list\"}}]"
+context="\"https://ddmal.music.mcgill.ca/Neon/contexts/1/manifest.jsonld\""
 imports=""
 json=""
 doc="/**\n * Pages that can be loaded.\n * @type {{name: string, mei: string, img: string}[]}\n */"

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -14,7 +14,7 @@ const meiUpload = path.join(__base, 'public', 'uploads', 'mei');
 const imgUpload = path.join(__base, 'public', 'uploads', 'img');
 const iiifUpload = path.join(__base, 'public', 'uploads', 'iiif');
 const iiifPublicPath = path.join('/', 'uploads', 'iiif');
-const neonContext = JSON.parse(fs.readFileSync(path.join(__base, 'src', 'utils', 'manifest', 'context.json')).toString());
+const neonContext = 'https://ddmal.music.mcgill.ca/Neon/contexts/1/manifest.jsonld';
 
 const allowedPattern = /^[-_\.,\d\w ]+$/;
 const consequtivePeriods = /\.{2,}/;

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -1,4 +1,4 @@
-import { NeonManifest } from './utils/NeonManifest';
+import { NeonManifest } from './Types';
 import NeonView from './NeonView';
 import ZoomHandler from './SingleView/Zoom';
 

--- a/src/NeonCore.ts
+++ b/src/NeonCore.ts
@@ -1,8 +1,7 @@
 import { convertSbToStaff } from './utils/ConvertMei';
 import * as Validation from './Validation';
 import VerovioWrapper from './VerovioWrapper';
-import { NeonManifest, Annotation } from './utils/NeonManifest';
-import { Attributes, EditorAction, VerovioMessage } from './Types';
+import { WebAnnotation, Attributes, EditorAction, NeonManifest, VerovioMessage } from './Types';
 import * as uuid from 'uuid/v4';
 
 import PouchDB from 'pouchdb';
@@ -31,11 +30,11 @@ class NeonCore {
   /** Pages known not to have any associated MEI. */
   private blankPages: Array<string>;
   /** A collection of W3 Web Annotations. */
-  private annotations: Annotation[];
+  private annotations: WebAnnotation[];
   private manifest: NeonManifest;
   private lastPageLoaded: string;
 
-  getAnnotations (): Annotation[] { return this.annotations; }
+  getAnnotations (): WebAnnotation[] { return this.annotations; }
 
   /**
    * Constructor for NeonCore
@@ -78,7 +77,7 @@ class NeonCore {
    */
   async initDb (force = false): Promise<{}> {
     // Check for existing manifest
-    type DbAnnotation = PouchDB.Core.IdMeta & PouchDB.Core.GetMeta & Annotation;
+    type DbAnnotation = PouchDB.Core.IdMeta & PouchDB.Core.GetMeta & WebAnnotation;
     type Doc = PouchDB.Core.IdMeta & PouchDB.Core.GetMeta & { timestamp: string; annotations: string[]};
     const response = await new Promise<{}>((resolve, reject): void => {
       this.db.get(this.manifest['@id']).catch(err => {

--- a/src/NeonView.ts
+++ b/src/NeonView.ts
@@ -1,6 +1,6 @@
 import NeonCore from './NeonCore';
 
-import { parseManifest, NeonManifest } from './utils/NeonManifest';
+import { parseManifest } from './utils/NeonManifest';
 import { prepareEditMode } from './utils/EditControls';
 import setBody from './utils/template/Template';
 import * as Types from './Types';
@@ -13,7 +13,7 @@ import * as Interfaces from './Interfaces';
  */
 class NeonView {
   /** The manifest describing what to load and where to find it. */
-  manifest: NeonManifest;
+  manifest: Types.NeonManifest;
   /** Module that displays rendered MEI. */
   view: Interfaces.ViewInterface;
   /** Name of the document loaded. */

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -16,3 +16,18 @@ export type VerovioMessage = {
   elementId?: string;
   editorAction?: EditorAction;
 };
+
+export type WebAnnotation = {
+  id: string;
+  type: string;
+  body: string;
+  target: string;
+};
+
+export type NeonManifest = {
+  '@context': Array<string | object> | string;
+  title: string;
+  timestamp: string;
+  image: string;
+  mei_annotations: WebAnnotation[];
+};

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -7,7 +7,7 @@ import SingleEditMode from './SquareEdit/SingleEditMode';
 import InfoModule from './InfoModule';
 import TextView from './TextView';
 import TextEditMode from './TextEditMode';
-import { NeonManifest } from './utils/NeonManifest';
+import { NeonManifest } from './Types';
 
 declare let manifestText: string;
 

--- a/src/utils/NeonManifest.ts
+++ b/src/utils/NeonManifest.ts
@@ -15,6 +15,9 @@ export function parseManifest (manifestString: NeonManifest): boolean {
     return false;
   }
   const context = instance['@context'];
+  if (context === 'https://ddmal.music.mcgill.ca/Neon/contexts/1/manifest.jsonld') {
+    return true;
+  }
   if ((context[0] === NeonContext[0]) &&
       (context[1]['schema'] === NeonContext[1]['schema']) &&
       (context[1]['title'] === NeonContext[1]['title']) &&

--- a/src/utils/NeonManifest.ts
+++ b/src/utils/NeonManifest.ts
@@ -1,4 +1,4 @@
-/** @module utils/NeonManifest */
+import { NeonManifest } from '../Types';
 const NeonSchema = require('./manifest/NeonSchema.json');
 const NeonContext = require('./manifest/context.json');
 
@@ -34,19 +34,4 @@ export function parseManifest (manifestString: NeonManifest): boolean {
     console.error(NeonContext);
     return false;
   }
-}
-
-export interface Annotation {
-  id: string;
-  type: string;
-  body: string;
-  target: string;
-}
-
-export interface NeonManifest {
-  '@context': Array<any>;
-  title: string;
-  timestamp: string;
-  image: string;
-  mei_annotations: Annotation[];
 }

--- a/src/utils/manifest/NeonSchema.json
+++ b/src/utils/manifest/NeonSchema.json
@@ -9,7 +9,7 @@
   ],
   "properties": {
     "@context": {
-      "type": "array"
+      "type": ["array", "string"]
     },
     "title": {
       "type": "string"

--- a/test/resources/test.jsonld
+++ b/test/resources/test.jsonld
@@ -1,21 +1,5 @@
 {
-    "@context": [
-        "http://www.w3.org/ns/anno.jsonld",
-        {
-            "schema": "http://schema.org/",
-            "title": "schema:name",
-            "timestamp": "schema:dateModified",
-            "image": {
-                "@id": "schema:image",
-                "@type": "@id"
-            },
-            "mei_annotations": {
-                "@id": "Annotation",
-                "@type": "@id",
-                "@container": "@list"
-            }
-        }
-    ],
+    "@context": "https://ddmal.music.mcgill.ca/Neon/contexts/1/manifest.jsonld",
     "@id": "/uploads/manifests/test.jsonld",
     "title": "Neon View Test Manifest",
     "timestamp": "2019-06-27T16:49:39-0400",

--- a/test/test/diva-test/manifest.jsonld
+++ b/test/test/diva-test/manifest.jsonld
@@ -1,21 +1,5 @@
 {
-    "@context": [
-        "http://www.w3.org/ns/anno.jsonld",
-        {
-            "schema": "http://schema.org/",
-            "title": "schema:name",
-            "timestamp": "schema:dateModified",
-            "image": {
-                "@id": "schema:image",
-                "@type": "@id"
-            },
-            "mei_annotations": {
-                "@id": "Annotation",
-                "@type": "@id",
-                "@container": "@list"
-            }
-        }
-    ],
+    "@context": "https://ddmal.music.mcgill.ca/Neon/contexts/1/manifest.jsonld",
     "@id": "/uploads/iiif/test/diva-test/manifest.jsonld",
     "title": "test",
     "timestamp": "2019-07-03T12:14:04.168Z",


### PR DESCRIPTION
Add support for external JSON-LD contexts when using a Neon manifest. This checks against the URL for the context (https://ddmal.music.mcgill.ca/Neon/contexts/1/manifest.jsonld) if a location is given and not an explicit context object.

Resolves #538.