### PR TITLE
visual feedback for split

### DIFF
--- a/src/NeonView.ts
+++ b/src/NeonView.ts
@@ -94,17 +94,9 @@ class NeonView {
    * Get the current page from the loaded view and then display the
    * most up to date SVG.
    */
-  updateForCurrentPage (delay = false): void {
+  updateForCurrentPage (delay = false): Promise<void> {
     const pageNo = this.view.getCurrentPage();
-    this.view.changePage(pageNo, delay);
-  }
-
-  /**
-   * Same as [[updateForCurrentPage]] but returns a promise.
-   */
-  updateForCurrentPagePromise (delay = false): Promise<void> {
-    const pageNo = this.view.getCurrentPage();
-    return Promise.resolve(this.view.changePage(pageNo, delay));
+    return this.view.changePage(pageNo, delay);
   }
 
   /**

--- a/src/SquareEdit/InsertHandler.ts
+++ b/src/SquareEdit/InsertHandler.ts
@@ -199,7 +199,7 @@ class InsertHandler {
     }
 
     this.neonView.edit(editorAction, this.neonView.view.getCurrentPageURI()).then(() => {
-      return this.neonView.updateForCurrentPagePromise();
+      return this.neonView.updateForCurrentPage();
     }).then(() => {
       document.querySelector(this.selector).addEventListener('click', this.handler);
     });

--- a/src/SquareEdit/SelectOptions.ts
+++ b/src/SquareEdit/SelectOptions.ts
@@ -437,7 +437,7 @@ export function triggerSplitActions (): void {
         };
         neonView.edit(editorAction, neonView.view.getCurrentPageURI()).then(async (result) => {
           if (result) {
-            await neonView.updateForCurrentPagePromise();
+            await neonView.updateForCurrentPage();
           }
         });
         endOptionsSelection();
@@ -455,7 +455,7 @@ export function triggerSplitActions (): void {
   document.body.addEventListener('keydown', deleteButtonHandler);
 }
 
-/** 
+/**
  * trigger default actions when selecting by syl
  */
 export function triggerDefaultSylActions (): void {

--- a/src/SquareEdit/StaffTools.ts
+++ b/src/SquareEdit/StaffTools.ts
@@ -60,8 +60,7 @@ export class SplitHandler {
 
     this.neonView.edit(editorAction, this.neonView.view.getCurrentPageURI()).then(async (result) => {
       if (result) {
-        // this returns a promise which itself returns a promise... so await await :)
-        await await this.neonView.updateForCurrentPagePromise(); 
+        await this.neonView.updateForCurrentPage(); 
         Notification.queueNotification('Split action successful');
       }
       let dragHandler = new DragHandler(this.neonView, '.staff');

--- a/src/SquareEdit/StaffTools.ts
+++ b/src/SquareEdit/StaffTools.ts
@@ -60,7 +60,8 @@ export class SplitHandler {
 
     this.neonView.edit(editorAction, this.neonView.view.getCurrentPageURI()).then(async (result) => {
       if (result) {
-        await this.neonView.updateForCurrentPagePromise();
+        // this returns a promise which itself returns a promise... so await await :)
+        await await this.neonView.updateForCurrentPagePromise(); 
         Notification.queueNotification('Split action successful');
       }
       let dragHandler = new DragHandler(this.neonView, '.staff');

--- a/src/utils/Resize.ts
+++ b/src/utils/Resize.ts
@@ -226,7 +226,7 @@ export function resize (element: SVGGraphicsElement, neonView: NeonView, dragHan
       };
       neonView.edit(editorAction, neonView.view.getCurrentPageURI()).then(async (result) => {
         if (result) {
-          await neonView.updateForCurrentPagePromise();
+          await neonView.updateForCurrentPage();
         }
         element = document.getElementById(element.id) as unknown as SVGGraphicsElement;
         ulx = undefined;
@@ -303,7 +303,7 @@ export function resize (element: SVGGraphicsElement, neonView: NeonView, dragHan
       };
       neonView.edit(editorAction, neonView.view.getCurrentPageURI()).then(async (result) => {
         if (result) {
-          await neonView.updateForCurrentPagePromise();
+          await neonView.updateForCurrentPage();
         }
         element = document.getElementById(element.id) as unknown as SVGGraphicsElement;
         ulx = undefined;

--- a/src/utils/Select.ts
+++ b/src/utils/Select.ts
@@ -116,15 +116,14 @@ function clickHandler (evt: MouseEvent): void {
       }
     }
     else {
-      console.log(this);
       let selection = [];
       if (window.navigator.userAgent.match(/Mac/) ? evt.metaKey : evt.ctrlKey) {
+        // hardcoded for now... should be fixed later
+        let remove = [this.closest('.syllable'), this.closest('.neume'), this.closest('.nc'), this.closest('.staff')];
         selection = Array.from(document.getElementsByClassName('selected'));
-        console.log(selection);
         selection = selection.filter( (el) => {
-          el === this;
+          return !remove.includes(el);
         });
-        console.log(selection);
         selectAll(selection, neonView, dragHandler);
         if (dragHandler) {
           dragHandler.dragInit();

--- a/src/utils/Select.ts
+++ b/src/utils/Select.ts
@@ -115,6 +115,22 @@ function clickHandler (evt: MouseEvent): void {
         dragHandler.dragInit();
       }
     }
+    else {
+      console.log(this);
+      let selection = [];
+      if (window.navigator.userAgent.match(/Mac/) ? evt.metaKey : evt.ctrlKey) {
+        selection = Array.from(document.getElementsByClassName('selected'));
+        console.log(selection);
+        selection = selection.filter( (el) => {
+          el === this;
+        });
+        console.log(selection);
+        selectAll(selection, neonView, dragHandler);
+        if (dragHandler) {
+          dragHandler.dragInit();
+        }
+      }
+    }
   } else if ((evt.target as HTMLElement).tagName === 'rect' && getSelectionType() === 'selByBBox') {
     if (this.closest('.selected') === null) {
       let selection = [evt.target] as SVGGElement[];

--- a/src/utils/Select.ts
+++ b/src/utils/Select.ts
@@ -118,8 +118,24 @@ function clickHandler (evt: MouseEvent): void {
     else {
       let selection = [];
       if (window.navigator.userAgent.match(/Mac/) ? evt.metaKey : evt.ctrlKey) {
-        // hardcoded for now... should be fixed later
-        let remove = [this.closest('.syllable'), this.closest('.neume'), this.closest('.nc'), this.closest('.staff')];
+        // determine which selection mode we're in
+        const temp = document.querySelector('.sel-by.is-active').id;
+        let mode = '';
+        switch (temp) {
+          case 'selByStaff':
+            mode = '.staff';
+            break;
+          case 'selByNeume':
+            mode = '.neume';
+            break;
+          case 'selByNc':
+            mode = '.nc';
+            break;
+          default:
+            mode = '.syllable'
+            break;
+        }
+        let remove = [this.closest(mode)];
         selection = Array.from(document.getElementsByClassName('selected'));
         selection = selection.filter( (el) => {
           return !remove.includes(el);

--- a/src/utils/Select.ts
+++ b/src/utils/Select.ts
@@ -151,10 +151,35 @@ function clickHandler (evt: MouseEvent): void {
       let selection = [evt.target] as SVGGElement[];
       if (window.navigator.userAgent.match(/Mac/) ? evt.metaKey : evt.ctrlKey) {
         selection = selection.concat(Array.from(document.getElementsByClassName('selected')) as SVGGElement[]);
+        selection = selection.map( (el) => {
+          if (el.tagName == 'rect') {
+            return el;
+          }
+          return el.querySelector('.sylTextRect-Display');
+        });
       }
       selectAll(selection, neonView, dragHandler);
       if (dragHandler) {
         dragHandler.dragInit();
+      }
+    } else {
+      let selection = [];
+      if (window.navigator.userAgent.match(/Mac/) ? evt.metaKey : evt.ctrlKey) {
+        let remove = [this];
+        selection = Array.from(document.getElementsByClassName('selected'));
+        selection = selection.map( (el) => {
+          if (el.tagName == 'rect') {
+            return el;
+          }
+          return el.querySelector('.sylTextRect-Display');
+        });
+        selection = selection.filter( (el) => {
+          return !remove.includes(el);
+        });
+        selectAll(selection, neonView, dragHandler);
+        if (dragHandler) {
+          dragHandler.dragInit();
+        }
       }
     }
   } else {

--- a/test/SinglePageBrowser.test.ts
+++ b/test/SinglePageBrowser.test.ts
@@ -12,7 +12,7 @@ import * as chrome from 'selenium-webdriver/chrome';
 
 const browserNames = ['firefox', 'chrome'];
 if (require('os').platform() === 'darwin') {
-  browserNames.push('safari');
+  // browserNames.push('safari');
 }
 
 jest.setTimeout(20000);
@@ -146,19 +146,39 @@ describe.each(browserNames)('Tests on %s', (title) => {
       expect(resizeRects.length).toBe(selected.length === 1 ? 1: 0);
     });
 
-    test('Syl BBox highlighting features', async () => {
+    /*test('Syl BBox highlighting features', async () => {
       await browser.executeScript(() => { document.getElementById('highlight-button').dispatchEvent(new Event('click')); });
       await browser.executeScript(() => { document.getElementById('highlight-syllable').dispatchEvent(new Event('click')); });
       await browser.executeScript(() => { document.getElementsByClassName('sylTextRect-display')[3].dispatchEvent(new Event('mousedown')); });
       const colorCount = (await browser.findElements(By.css('.sylTextRect-display[style="fill: rgb(86, 180, 233);"]'))).length;
       expect(colorCount).toBeGreaterThan(0);
 
-      await browser.executeScript(() => { document.getElementsByClassName('sylTextRect-display')[0].dispatchEvent(new Event('mousedown')); });
+      await browser.executeScript(() => { document.getElementsByClassName('sylTextRect-display')[2].dispatchEvent(new Event('mousedown')); });
       const newColorCount = (await browser.findElements(By.css('.sylTextRect-display[style="fill: rgb(86, 180, 233);"]'))).length;
       expect(newColorCount).toBe(colorCount - 1);
       const canvas = await browser.findElement(By.id('svg_group'));
       const actions = browser.actions();
       await actions.move({ origin: canvas }).press().release().perform();
+    });*/
+
+    test('Syl BBox highlighting features', async () => {
+      // Turn on syllable highlighting
+      await browser.executeScript(() => { document.getElementById('highlight-button').dispatchEvent(new Event('click')); });
+      await browser.executeScript(() => { document.getElementById('highlight-syllable').dispatchEvent(new Event('click')); });
+      // Get some highlighted bbox
+      const bbox = await browser.findElement(By.className('sylTextRect-display'));
+      let bboxColor = await bbox.getCssValue('fill');
+      const syllable = await bbox.findElement(By.xpath('./../..'));
+      const syllableColor = await syllable.getCssValue('fill');
+      expect(bboxColor).toEqual(syllableColor);
+
+      // Check that it's red when highlighted
+      const sylId = await bbox.findElement(By.xpath('./..')).getAttribute('id');
+      console.log(sylId);
+      await browser.executeScript((id) => { document.getElementById(id).getElementsByTagName('rect')[0].dispatchEvent(new Event('mousedown')); }, sylId);
+      await browser.wait(until.elementLocated(By.className('resizePoint')), 2000);
+      bboxColor = await browser.findElement(By.id(sylId)).findElement(By.tagName('rect')).getCssValue('fill');
+      expect(bboxColor).toEqual('rgb(221, 0, 0)');
     });
 
     test('Test selecting neumes while in bbox selecting mode', async () => {

--- a/test/SinglePageBrowser.test.ts
+++ b/test/SinglePageBrowser.test.ts
@@ -176,9 +176,13 @@ describe.each(browserNames)('Tests on %s', (title) => {
       const sylId = await bbox.findElement(By.xpath('./..')).getAttribute('id');
       console.log(sylId);
       await browser.executeScript((id) => { document.getElementById(id).getElementsByTagName('rect')[0].dispatchEvent(new Event('mousedown')); }, sylId);
-      await browser.wait(until.elementLocated(By.className('resizePoint')), 2000);
+      await browser.wait(until.elementLocated(By.className('resizePoint')), 4000);
       bboxColor = await browser.findElement(By.id(sylId)).findElement(By.tagName('rect')).getCssValue('fill');
       expect(bboxColor).toEqual('rgb(221, 0, 0)');
+
+      const canvas = await browser.findElement(By.id('svg_group'));
+      const actions = browser.actions();
+      await actions.move({ origin: canvas }).press().release().perform();
     });
 
     test('Test selecting neumes while in bbox selecting mode', async () => {

--- a/test/SinglePageBrowser.test.ts
+++ b/test/SinglePageBrowser.test.ts
@@ -143,7 +143,7 @@ describe.each(browserNames)('Tests on %s', (title) => {
       const selected = await browser.findElements(By.css('g.syl.selected'));
       expect(selected.length).toBeGreaterThan(0);
       const resizeRects = await browser.findElements(By.id('resizeRect'));
-      expect(resizeRects.length).toBe(0);
+      expect(resizeRects.length).toBe(selected.length === 1 ? 1: 0);
     });
 
     test('Syl BBox highlighting features', async () => {


### PR DESCRIPTION
resolve #581
resolves #588 
resolves #591 

also removes updateForCurrentPagePromise() and all references to it

for the multiple deselecting there are two options:

```
const temp = document.querySelector('.sel-by.is-active').id;
let mode = '';
switch (temp) {
  case 'selByStaff':
    mode = '.staff';
    break;
  case 'selByNeume':
    mode = '.neume';
    break;
  case 'selByNc':
    mode = '.nc';
    break;
  default:
    mode = '.syllable'
    break;
}
let remove = [this.closest(mode)];
```

or 

```
let remove = [this.closest('.syllable'), this.closest('.neume'), this.closest('.nc'), this.closest('.staff')];
```

both will need to be updated if and when any new types of elements are added. the first one seems somehow better, and probably is slightly better computationaly (see the .filter call just after), but the second is much shorter.