### PR TITLE
Apply event listener to SVG element instead of G

### DIFF
--- a/src/DisplayPanel/DisplayControls.ts
+++ b/src/DisplayPanel/DisplayControls.ts
@@ -19,7 +19,7 @@ export function initDisplayControls (meiClassName: string, background: string): 
   const displayContents = document.getElementById('displayContents');
   const toggleDisplay = document.getElementById('toggleDisplay');
 
-  toggleDisplay.addEventListener('click', () => {
+  toggleDisplay.parentElement.addEventListener('click', () => {
     if (displayContents.style.display === 'none') {
       displayContents.style.display = '';
       toggleDisplay.setAttribute('xlink:href', __ASSET_PREFIX__ + 'assets/img/icons.svg' + '#dropdown-down');

--- a/src/SquareEdit/Controls.ts
+++ b/src/SquareEdit/Controls.ts
@@ -60,7 +60,7 @@ export function initInsertEditControls () {
   const toggleEdit = document.getElementById('toggleEdit');
   const insertContents = document.getElementById('insertContents');
   const editContents = document.getElementById('editContents');
-  toggleInsert.addEventListener('click', () => {
+  toggleInsert.parentElement.addEventListener('click', () => {
     if (insertContents.style.display === 'none') {
       insertContents.style.display = '';
       toggleInsert.setAttribute('xlink:href', __ASSET_PREFIX__ + 'assets/img/icons.svg' + '#dropdown-down');
@@ -70,7 +70,7 @@ export function initInsertEditControls () {
     }
   });
 
-  toggleEdit.addEventListener('click', () => {
+  toggleEdit.parentElement.addEventListener('click', () => {
     if (editContents.style.display === 'none') {
       editContents.style.display = '';
       toggleEdit.setAttribute('xlink:href', __ASSET_PREFIX__ + 'assets/img/icons.svg' + '#dropdown-down');


### PR DESCRIPTION
This makes it so the user only needs to click on the actual SVG where
the triangle is rather than only on the triangle.

Fix #585.