### PR TITLE
Get viewBox from background image

### DIFF
--- a/deployment/server/editor.ts
+++ b/deployment/server/editor.ts
@@ -25,15 +25,18 @@ async function init (): Promise<void> {
       View: undefined,
       NeumeEdit: undefined
     };
-    const mediaType = await window.fetch(manifest.image).then(response => {
-      if (response.ok) {
-        return response.headers.get('Content-Type');
-      } else {
-        throw new Error(response.statusText);
-      }
-    });
+    let singlePage: boolean;
+    switch (manifest.mei_annotations.length) {
+      case 0:
+        throw new Error('Cannot load Neon without any MEI files!');
+        break;
+      case 1:
+        singlePage = true;
+        break;
+      default:
+        singlePage = false;
+    }
 
-    const singlePage = mediaType.match(/^image\/*/);
     params.View = singlePage ? SingleView : DivaView;
     params.NeumeEdit = singlePage ? SingleEditMode : DivaEdit;
 

--- a/src/SingleView/SingleView.ts
+++ b/src/SingleView/SingleView.ts
@@ -36,9 +36,24 @@ class SingleView implements ViewInterface {
     this.bg = document.createElementNS('http://www.w3.org/2000/svg', 'image');
     this.bg.id = 'bgimg';
     this.bg.classList.add('background');
-    this.bg.setAttributeNS('http://www.w3.org/1999/xlink', 'href', image);
     this.bg.setAttribute('x', '0');
     this.bg.setAttribute('y', '0');
+
+    const reader = new FileReader();
+    fetch(image).then(result => {
+      if (result.ok) {
+        reader.addEventListener('load', () => {
+          this.bg.setAttributeNS('http://www.w3.org/1999/xlink', 'href', reader.result.toString());
+          const bbox = this.bg.getBBox();
+          if (!this.group.hasAttribute('viewBox')) {
+            this.group.setAttribute('viewBox', '0 0 ' + bbox.width.toString() + ' ' + bbox.height.toString());
+          }
+        });
+        return result.blob();
+      }
+    }).then(blob => {
+      reader.readAsDataURL(blob);
+    });
 
     this.mei = document.createElementNS('http://www.w3.org/svg', 'svg') as SVGSVGElement;
     this.mei.id = 'mei_output';


### PR DESCRIPTION
Neon needs the bounds of the source to create the `viewBox` for the SVG containing (in single page mode) the background image and rendered MEI. This allows gets a tentative BBox from the background image itself and uses that to set the `viewBox`, which should make the page appear normally before the MEI loads (or if the MEI is not formatted correctly).

Also the viewer mode to load in is determined by the number of annotations in the manifest file, not by loading the content of `manifest.image` and seeing if it is a IIIF manifest or an actual (large) image file.