### PR TITLE
Only delete documents used in NeonCore

### DIFF
--- a/src/NeonCore.ts
+++ b/src/NeonCore.ts
@@ -540,8 +540,20 @@ class NeonCore {
   }
 
   /** Completely remove the database. */
-  deleteDb (): Promise<void> {
-    return this.db.destroy();
+  async deleteDb (): Promise<{}[]> {
+    type Doc = PouchDB.Core.IdMeta & PouchDB.Core.GetMeta & { timestamp: string; annotations: string[]};
+    const annotations = await this.db.get(this.manifest['@id'])
+      .then((doc: Doc) => { return doc.annotations; } );
+    annotations.push(this.manifest['@id']);
+
+    const promises = annotations.map((id) => {
+      return new Promise(res => {
+        this.db.get(id)
+          .then(doc => { return this.db.remove(doc); })
+          .then(() => res());
+      });
+    });
+    return Promise.all(promises);
   }
 }
 

--- a/src/NeonView.ts
+++ b/src/NeonView.ts
@@ -174,7 +174,7 @@ class NeonView {
   /**
    * Deletes the local database of the loaded MEI file(s).
    */
-  deleteDb (): Promise<void> {
+  deleteDb (): Promise<{}[]> {
     return this.core.deleteDb();
   }
 


### PR DESCRIPTION
Specifically just delete the documents for the manifest and annotations
in that manifest and NOT the entire database for Neon.

Resolve #621.