### PR TITLE
Fixed #681 by adding syl action triggers to groups

### DIFF
--- a/src/utils/SelectTools.ts
+++ b/src/utils/SelectTools.ts
@@ -388,13 +388,16 @@ export async function selectAll (elements: Array<SVGGraphicsElement>, neonView: 
               }
             }
             SelectOptions.triggerDefaultSylActions();
+            SelectOptions.triggerSylActions();
           }
           break;
         default:
           if (sharedSecondLevelParent(groups)) {
             Grouping.triggerGrouping('syl');
+            SelectOptions.triggerSylActions();
           } else {
             SelectOptions.triggerDefaultSylActions();
+            SelectOptions.triggerSylActions();
           }
       }
       break;


### PR DESCRIPTION
I added `console.log()` statements to all functions that called the `changeStaffHandler` and the issue seemed to be `groupsToSelect` not calling the necessary functions to trigger the button. I've added it to all three sections with possible syllable calls but it may not be needed in all of them. 