### PR TITLE
Add bounding box and highlight mode key shortcuts

### DIFF
--- a/src/DisplayPanel/DisplayControls.ts
+++ b/src/DisplayPanel/DisplayControls.ts
@@ -217,7 +217,6 @@ function setHighlightKeyControls (): void {
   document.body.addEventListener('keydown', (evt) => {
     switch (evt.key) {
       case 'q':
-        console.log('hello???');
         updateHighlightOption('staff', 'staff', 'Staff');
         break;
       case 'w':

--- a/src/SingleView/SingleView.ts
+++ b/src/SingleView/SingleView.ts
@@ -152,6 +152,7 @@ class SingleView implements ViewInterface {
   setViewEventHandlers (): void {
     document.body.addEventListener('keydown', (evt) => {
       switch (evt.key) {
+        // Shift: allow dragging the display
         case 'Shift':
           d3.select('#svg_group').on('.drag', null);
           d3.select('#svg_group').call(
@@ -159,6 +160,7 @@ class SingleView implements ViewInterface {
               .on('drag', this.displayPanel.zoomHandler.dragging.bind(this.displayPanel.zoomHandler))
           );
           break;
+        // h: hide MEI output
         case 'h':
           document.getElementById('mei_output').setAttribute('visibility', 'hidden');
           break;

--- a/src/SquareEdit/Grouping.ts
+++ b/src/SquareEdit/Grouping.ts
@@ -1,6 +1,7 @@
 import * as Contents from './Contents';
 import * as Warnings from '../Warnings';
 import * as Notification from '../utils/Notification';
+import * as SelectTools from '../utils/SelectTools';
 import NeonView from '../NeonView';
 import { EditorAction } from '../Types';
 import { unsetVirgaAction, unsetInclinatumAction, removeHandler, deleteButtonHandler } from './SelectOptions';
@@ -46,6 +47,9 @@ export function initGroupingListeners (): void {
   del.removeEventListener('click', removeHandler);
   del.addEventListener('click', removeHandler);
   document.body.addEventListener('keydown', deleteButtonHandler);
+
+  document.body.removeEventListener('keydown', groupingKeyBindingsListener);
+  document.body.addEventListener('keydown', groupingKeyBindingsListener);
   try {
     document.getElementById('mergeSyls').addEventListener('click', () => {
       const elementIds = getChildrenIds().filter(e =>
@@ -56,6 +60,7 @@ export function initGroupingListeners (): void {
   } catch (e) {}
 
   try {
+
     document.getElementById('groupNeumes').addEventListener('click', () => {
       const elementIds = getIds();
       groupingAction('group', 'neume', elementIds);
@@ -221,6 +226,57 @@ export function initGroupingListeners (): void {
 }
 
 /**
+ * Grouping keybinding event listener
+ */
+ export const groupingKeyBindingsListener = function(e) {
+
+  console.log(SelectTools.getSelectionType());
+
+  console.log('initializing keybinding events');
+
+  if (e.key === "g") {
+
+    // group syls
+    if (document.getElementById('mergeSyls')) {
+      console.log('mergeSyls');
+      const elementIds = getChildrenIds().filter(e =>
+        document.getElementById(e).classList.contains('neume')
+      );
+      groupingAction('group', 'neume', elementIds);      
+    }
+
+    // group neumes
+    if (document.getElementById('groupNeumes')) {
+      console.log('groupNeumes');
+      const elementIds = getIds();
+      groupingAction('group', 'neume', elementIds);
+    }
+
+    // group Ncs
+    if (document.getElementById('groupNcs')) {
+      console.log('groupNcs');
+      const elementIds = getIds();
+      groupingAction('group', 'nc', elementIds);
+    }
+
+    // ungroup neumes
+    if (document.getElementById('ungroupNeumes')) {
+      console.log('ungroupNeumes');
+      const elementIds = getIds();
+      groupingAction('ungroup', 'neume', elementIds);
+    }
+
+    // ungroup Ncs
+    if (document.getElementById('ungroupNcs')) {
+      console.log('ungroupNcs');
+      const elementIds = getIds();
+      groupingAction('ungroup', 'nc', elementIds);
+    }
+  }
+
+ }
+
+/**
  * Form and execute a group/ungroup action.
  * @param action - The action to execute. Either "group" or "ungroup".
  * @param groupType - The type of elements to group. Either "neume" or "nc".
@@ -292,3 +348,5 @@ function getChildrenIds (): string[] {
   });
   return childrenIds;
 }
+
+

--- a/src/SquareEdit/Grouping.ts
+++ b/src/SquareEdit/Grouping.ts
@@ -226,55 +226,45 @@ export function initGroupingListeners (): void {
 }
 
 /**
- * Grouping keybinding event listener
+ * Grouping/Ungrouping keybinding event listener
  */
- export const groupingKeyBindingsListener = function(e) {
+const groupingKeyBindingsListener = function(e) {
 
-  console.log(SelectTools.getSelectionType());
-
-  console.log('initializing keybinding events');
-
+  // if grouping keybinding is pressed
   if (e.key === "g") {
+    // get selected elements to check if they can be groupeds
+    const elements = Array.from(document.querySelectorAll('.selected')) as SVGGraphicsElement[];
 
-    // group syls
-    if (document.getElementById('mergeSyls')) {
-      console.log('mergeSyls');
+    // group/ingroup syls
+    if (SelectTools.getSelectionType() === 'selBySyl') {
       const elementIds = getChildrenIds().filter(e =>
         document.getElementById(e).classList.contains('neume')
       );
-      groupingAction('group', 'neume', elementIds);      
-    }
-
-    // group neumes
-    if (document.getElementById('groupNeumes')) {
-      console.log('groupNeumes');
-      const elementIds = getIds();
       groupingAction('group', 'neume', elementIds);
     }
-
-    // group Ncs
-    if (document.getElementById('groupNcs')) {
-      console.log('groupNcs');
-      const elementIds = getIds();
-      groupingAction('group', 'nc', elementIds);
+    // group/ungroup neumes
+    if (SelectTools.getSelectionType() === 'selByNeume') {
+      if (SelectTools.canBeGrouped(elements)) { // can be grouped?
+        const elementIds = getIds();
+        groupingAction('group', 'neume', elementIds);
+      } else {
+        const elementIds = getChildrenIds();
+        groupingAction('ungroup', 'nc', elementIds);
+      }
     }
-
-    // ungroup neumes
-    if (document.getElementById('ungroupNeumes')) {
-      console.log('ungroupNeumes');
-      const elementIds = getIds();
-      groupingAction('ungroup', 'neume', elementIds);
-    }
-
-    // ungroup Ncs
-    if (document.getElementById('ungroupNcs')) {
-      console.log('ungroupNcs');
-      const elementIds = getIds();
-      groupingAction('ungroup', 'nc', elementIds);
+    // group/ungroup Ncs
+    if (SelectTools.getSelectionType() === 'selByNc') {
+      if (SelectTools.canBeGrouped(elements)) { // can be grouped?
+        const elementIds = getIds();
+        groupingAction('group', 'nc', elementIds);
+      } else {
+        const elementIds = getChildrenIds();
+        groupingAction('ungroup', 'nc', elementIds);
+      }
     }
   }
+}
 
- }
 
 /**
  * Form and execute a group/ungroup action.
@@ -348,5 +338,3 @@ function getChildrenIds (): string[] {
   });
   return childrenIds;
 }
-
-

--- a/src/SquareEdit/InsertHandler.ts
+++ b/src/SquareEdit/InsertHandler.ts
@@ -9,7 +9,7 @@ class InsertHandler {
   type: string;
   firstClick = true;
   coord: DOMPoint;
-  attributes: object;
+  attributes: Record<string, string>;
   selector: string;
   neonView: NeonView;
 

--- a/src/TextView.ts
+++ b/src/TextView.ts
@@ -66,7 +66,7 @@ class TextView implements TextViewInterface {
    * Update visibility of text bounding boxes
    */
   updateBBoxViewVisibility (): void {
-    if ((document.getElementById('displayBBox')as HTMLInputElement).checked) {
+    if ((document.getElementById('displayBBox') as HTMLInputElement).checked) {
       document.querySelectorAll('.sylTextRect').forEach(rect => {
         rect.classList.add('sylTextRect-display');
         rect.classList.remove('sylTextRect');

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -43,3 +43,9 @@ export type NeonManifest = {
   image: string;
   mei_annotations: WebAnnotation[];
 };
+
+/** An <svg> element from any DOM queries */
+export type HTMLSVGElement = HTMLElement & SVGSVGElement;
+
+/** "Selection By" type */
+export type SelectionType = 'selByStaff' | 'selByNeume' | 'selByNc' | 'selByLayerElement' | 'selBySyl' | 'selByBBox' | 'selByLayerElement';

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -49,3 +49,6 @@ export type HTMLSVGElement = HTMLElement & SVGSVGElement;
 
 /** "Selection By" type */
 export type SelectionType = 'selByStaff' | 'selByNeume' | 'selByNc' | 'selByLayerElement' | 'selBySyl' | 'selByBBox' | 'selByLayerElement';
+
+/** Highlight grouping type  */
+export type Grouping = 'staff' | 'syllable' | 'neume' | 'layer' | 'selection' | 'none';

--- a/src/utils/Color.ts
+++ b/src/utils/Color.ts
@@ -1,3 +1,5 @@
+import { Grouping } from '../Types';
+
 /**
  * Adapted from color palette from Figure 2 (Colors optimized for color-blind
  * individuals) from
@@ -42,7 +44,7 @@ export function unhighlight(staff?: SVGGElement): void {
           rect.closest('.staff').classList.contains('selected') ||
           rect.closest('.syl').classList.contains('selected')
           // rect.closest('.layer').classList.contains('selected')
-          ){
+        ){
           rect.style.fill = 'red';
         } else {
           rect.style.fill = 'blue';
@@ -169,9 +171,9 @@ export function setStaffHighlight(): void {
 
 /**
  * Set a highlight by a different grouping.
- * @param grouping - Either "staff", "syllable", "neume", or "layer".
+ * @param grouping - Either "staff", "syllable", "neume", "selection", or "layer".
  */
-export function setGroupingHighlight(grouping: string): void {
+export function setGroupingHighlight(grouping: Grouping): void {
   unsetGroupingHighlight();
   if (grouping === 'staff') {
     setStaffHighlight();
@@ -200,7 +202,7 @@ export function setGroupingHighlight(grouping: string): void {
   let groups;
 
   if (grouping == 'layer') {
-    groups = document.querySelectorAll(".accid, .clef, .custos, .divLine");
+    groups = document.querySelectorAll('.accid, .clef, .custos, .divLine');
   }
   else {
     groups = document.getElementsByClassName(grouping) as HTMLCollectionOf<HTMLElement>;

--- a/src/utils/Select.ts
+++ b/src/utils/Select.ts
@@ -46,37 +46,23 @@ function arrowKeyListener (evt: KeyboardEvent): void {
   if (getSelectionType() !== 'selByBBox' || (evt.key !== 'ArrowLeft' && evt.key !== 'ArrowRight'))
     return;
 
-  // Find the position of the currently selected BBox in the list of all BBoxes
-  const width = (document.getElementById('mei_output') as HTMLSVGElement).width.baseVal.value;
+  const selected = document.querySelector('.syllable-highlighted');
+  const syllables = Array.from(document.querySelectorAll('.syllable'));
 
-  // Sort BBoxes by coordinates by flattening the 2D plane to 1D
-  function sortByCoords(a: SVGRectElement, b: SVGRectElement): number {
-    const aVal = a.x.baseVal.value + width * a.y.baseVal.value;
-    const bVal = b.x.baseVal.value + width * b.y.baseVal.value;
+  // not all syllables have BBoxes; we must filter them out
+  const bboxSyllables = syllables.filter(syl => syl.querySelector('.sylTextRect-display') !== null);
+  const ind = bboxSyllables.indexOf(selected);
 
-    return aVal - bVal;
-  }
+  if (evt.key === 'ArrowLeft' && ind > 0) {
+    unselect();
 
-  const bboxes = Array.from(document.querySelectorAll('.sylTextRect-display'));
-  bboxes.sort(sortByCoords);
+    const bbox = bboxSyllables[ind - 1].querySelector('.sylTextRect-display');
+    selectAll([bbox as SVGGraphicsElement], neonView, dragHandler);
+  } else if (evt.key === 'ArrowRight' && ind < bboxSyllables.length - 1) {
+    unselect();
 
-  const selectedSyl = document.querySelector('.selected').querySelector('.sylTextRect-display');
-  const ind = bboxes.indexOf(selectedSyl);
-
-  if (evt.key === 'ArrowLeft') {
-    // console.log('left pressed');
-
-    if (ind !== 0) {
-      unselect();
-      selectAll([bboxes[ind - 1] as SVGGraphicsElement], neonView, dragHandler);
-    }
-  } else if (evt.key === 'ArrowRight') {
-    // console.log('right');
-
-    if (ind !== bboxes.length - 1) {
-      unselect();
-      selectAll([bboxes[ind + 1] as SVGGraphicsElement], neonView, dragHandler);
-    }
+    const bbox = bboxSyllables[ind + 1].querySelector('.sylTextRect-display');
+    selectAll([bbox as SVGGraphicsElement], neonView, dragHandler);
   }
 }
 

--- a/src/utils/Select.ts
+++ b/src/utils/Select.ts
@@ -1,7 +1,7 @@
 /** @module utils/Select */
 
 import {
-  unselect, getStaffBBox, selectStaff, selectLayerElement, selectAll, getSelectionType
+  unselect, getStaffBBox, selectStaff, selectAll, getSelectionType
 } from './SelectTools';
 import { resize } from './Resize';
 import NeonView from '../NeonView';
@@ -10,7 +10,6 @@ import { InfoInterface } from '../Interfaces';
 import ZoomHandler from '../SingleView/Zoom';
 
 import * as d3 from 'd3';
-import { HTMLSVGElement } from '../Types';
 
 let dragHandler: DragHandler, neonView: NeonView, info: InfoInterface, zoomHandler: ZoomHandler;
 let strokeWidth = 7;

--- a/src/utils/SelectTools.ts
+++ b/src/utils/SelectTools.ts
@@ -21,6 +21,29 @@ export function getSelectionType (): SelectionType {
 }
 
 /**
+ * Check if selected elements can be grouped or not
+ * @returns true if grouped, false otherwise
+ */
+ export function canBeGrouped (elements: Array<SVGGraphicsElement>): boolean {
+  const groups = Array.from(elements.values()) as SVGGraphicsElement[];
+
+  switch (groups.length) {
+    case 1:
+      // cannot group if only 1 element is selected
+      return false;
+      break;
+    default:
+      // can group if more than 1 element is selected
+      // Note: is this true? Might need to add more checks for Ncs etc.
+      if (sharedSecondLevelParent(groups)) {
+        return true;
+      } else {
+        return false
+      }
+  }
+}
+
+/**
  * Unselect all selected elements and run undo any extra
  * actions.
  */

--- a/src/utils/SelectTools.ts
+++ b/src/utils/SelectTools.ts
@@ -2,7 +2,7 @@ import * as Color from './Color';
 import { updateHighlight } from '../DisplayPanel/DisplayControls';
 import * as Grouping from '../SquareEdit/Grouping';
 import { resize } from './Resize';
-import { Attributes } from '../Types';
+import { Attributes, SelectionType } from '../Types';
 import NeonView from '../NeonView';
 import DragHandler from './DragHandler';
 import * as SelectOptions from '../SquareEdit/SelectOptions';
@@ -11,10 +11,10 @@ import * as d3 from 'd3';
 /**
  * @returns The selection mode chosen by the user.
  */
-export function getSelectionType (): string {
+export function getSelectionType (): SelectionType {
   const element = document.getElementsByClassName('sel-by is-active');
   if (element.length !== 0) {
-    return element[0].id;
+    return element[0].id as SelectionType;
   } else {
     return null;
   }


### PR DESCRIPTION
## Shortcut 1: Move between bounding boxes by arrow keys
Adds feature requested by @carrieeex in issue #665 to use arrow keys for moving between bounding boxes.

> It would be nice if we can use arrow keys (left and right) to switch between different bounding boxes. For example, when users choose "select by BBox", and then click one of the bounding boxes, press the right arrow key would switch to the BBox on the right.

Demo:

https://user-images.githubusercontent.com/40512164/167648259-9f4c0e5c-f1fe-4d19-9104-40f55601e24b.mov

EDIT:

Arrow keys now move correctly through syllables.

https://user-images.githubusercontent.com/40512164/167668314-40c98e51-917e-4510-a7ad-e85330b46b73.mov

## Shortcut 2: Switch highlight modes using q, w, e, r, t, and y keys
Again, from issue #665. 

Demo:

https://user-images.githubusercontent.com/40512164/167684349-7dbb39d4-e889-49f8-8ea1-86005f20b4b1.mov

@JoyfulGen How does this look?

