### PR TITLE
Fix files according to ESlint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,9 @@
         "browser": true,
         "es6": true
     },
-    "extends": "plugin:@typescript-eslint/recommended",
+    "extends": [
+        "plugin:@typescript-eslint/recommended"
+    ],
     "globals": {
         "Atomics": "readonly",
         "SharedArrayBuffer": "readonly"
@@ -33,14 +35,19 @@
             "error",
             "single"
         ],
+        "object-curly-spacing": [
+            "error",
+            "always"
+        ],
+        "quote-props": [
+            "error",
+            "as-needed"
+        ],
         "@typescript-eslint/semi": [
             "error",
             "always"
         ],
         "@typescript-eslint/no-var-requires": 1,
-        "@typescript-eslint/no-use-before-define": [
-            "warn"
-        ],
         "@typescript-eslint/no-unused-vars": [
             "error",
             {

--- a/src/DisplayPanel/DisplayControls.ts
+++ b/src/DisplayPanel/DisplayControls.ts
@@ -122,7 +122,7 @@ export function setOpacityFromSlider (meiClassName?: string): void {
       g.style.opacity = (Number(opacityOutput.value) / 100.0).toString();
     });
   } catch (e) {
-    console.warn("Unable to properly set opacity to pages");
+    console.warn('Unable to properly set opacity to pages');
   }
 }
 

--- a/src/InfoModule.ts
+++ b/src/InfoModule.ts
@@ -3,7 +3,6 @@
 import NeonView from './NeonView';
 import { InfoInterface } from './Interfaces';
 import { Attributes } from './Types';
-import { quickselect } from 'd3-array';
 
 /**
  * Map of contours to neume names.
@@ -183,10 +182,10 @@ class InfoModule implements InfoInterface {
         attributes = await this.neonView.getElementAttr(id, this.neonView.view.getCurrentPageURI());
         let type = '';
         if ((attributes['accid']).toUpperCase() == 'F'){
-          type = "Flat";
+          type = 'Flat';
         }
         else if((attributes['accid']).toUpperCase() == 'N'){
-          type = "Natural";
+          type = 'Natural';
         }
         body += 'Accid Type: ' + type;
         break;

--- a/src/SquareEdit/Contents.ts
+++ b/src/SquareEdit/Contents.ts
@@ -129,7 +129,7 @@ export const ncActionContents: string =
 /**
  * Contents of basic neume action menu.
  */
- export const defaultNeumeActionContents: string =
+export const defaultNeumeActionContents: string =
  '<div><p class=\'control\'>' +
  '<button class=\'button\' id=\'delete\'>Delete</button>' + 
  '<button class=\'button\' id=\'split-neume\'>Split Neumes</button></p></div>';
@@ -250,31 +250,31 @@ export const clefActionContents: string =
 /**
  * HTML for grouping selection menu.
  */
-export const groupingMenu: object = {
-  'nc': '<div class=\'field is-grouped\'>' +
+export const groupingMenu = {
+  nc: '<div class=\'field is-grouped\'>' +
         '<div><p class=\'control\'>' +
         '<button class=\'button\' id=\'groupNcs\'>Group Neume Components</button>' +
         '<button class=\'button\' id=\'delete\'>Delete</button></p></div>',
-  'neume': '<div class=\'field is-grouped\'>' +
+  neume: '<div class=\'field is-grouped\'>' +
         '<div><p class=\'control\'>' +
         '<button class=\'button\' id=\'groupNeumes\'>Group Neumes</button>' +
         '<button class=\'button\' id=\'delete\'>Delete</button></p></div>',
-  'syl': '<div class=\'field is-grouped\'>' +
+  syl: '<div class=\'field is-grouped\'>' +
         '<div><p class=\'control\'>' +
         '<button class=\'button\' id=\'mergeSyls\'>Merge Syllables</button>' +
         '<button class=\'button\' id=\'delete\'>Delete</button>' +
         '<button class=\'button\' id=\'changeStaff\'>Re-associate to nearest staff</button></p></div>',
-  'ligatureNc': '<div class=\'field is-grouped\'>' +
+  ligatureNc: '<div class=\'field is-grouped\'>' +
         '<div><p class=\'control\'>' +
         '<button class=\'button\' id=\'groupNcs\'>Group Neume Components</button></p></div>' +
         '<div><p class=\'control\'>' +
         '<button class=\'button\' id=\'toggle-ligature\'>Toggle Ligature</button>' +
         '<button class=\'button\' id=\'delete\'>Delete</button></p></div></div>',
-  'ligature': '<div class=\'field is-grouped\'>' +
+  ligature: '<div class=\'field is-grouped\'>' +
         '<div><p class=\'control\'>' +
         '<button class=\'button\' id=\'toggle-ligature\'>Toggle Ligature</button>' +
         '<button class=\'button\' id=\'delete\'>Delete</button></p></div></div>',
-  'splitSyllable': '<div class=\'field is-grouped\'>' +
+  splitSyllable: '<div class=\'field is-grouped\'>' +
         '<div><p class=\'control\'>' +
         '<button class=\'button\' id=\'toggle-link\'>Toggle Linked Syllables</button>' +
         '<button class=\'button\' id=\'delete\'>Delete</button></p></div></div>'

--- a/src/SquareEdit/Controls.ts
+++ b/src/SquareEdit/Controls.ts
@@ -9,7 +9,7 @@ import { NeumeEditInterface } from '../Interfaces';
 /**
  * Set listener on EditMode button.
  */
-export function initEditModeControls (editMode: NeumeEditInterface) {
+export function initEditModeControls (editMode: NeumeEditInterface): void {
   document.getElementById('edit_mode').addEventListener('click', function () {
     document.getElementById('insert_controls').innerHTML += Contents.insertControlsPanel;
     document.getElementById('edit_controls').innerHTML += Contents.editControlsPanel;
@@ -20,7 +20,7 @@ export function initEditModeControls (editMode: NeumeEditInterface) {
 /**
  * Bind listeners to insert tabs.'
  */
-export function bindInsertTabs (insertHandler: InsertHandler) {
+export function bindInsertTabs (insertHandler: InsertHandler): void {
   const insertTabs: Element[] = Array.from(document.getElementsByClassName('insertTab'));
   const tabIds: string[] = insertTabs.map((tab) => { return tab.id; });
 
@@ -55,7 +55,7 @@ export function bindInsertTabs (insertHandler: InsertHandler) {
 /**
  * Initialize Edit and Insert control panels.
  */
-export function initInsertEditControls () {
+export function initInsertEditControls (): void {
   const toggleInsert = document.getElementById('toggleInsert');
   const toggleEdit = document.getElementById('toggleEdit');
   const insertContents = document.getElementById('insertContents');
@@ -120,7 +120,7 @@ function bindElements (insertHandler: InsertHandler) {
 /**
  * Set listeners on the buttons to change selection modes.
  */
-export function initSelectionButtons () {
+export function initSelectionButtons (): void {
   const selBySyl = document.getElementById('selBySyl');
   const selByNeume = document.getElementById('selByNeume');
   const selByNc = document.getElementById('selByNc');

--- a/src/SquareEdit/Grouping.ts
+++ b/src/SquareEdit/Grouping.ts
@@ -3,7 +3,7 @@ import * as Warnings from '../Warnings';
 import * as Notification from '../utils/Notification';
 import NeonView from '../NeonView';
 import { EditorAction } from '../Types';
-import { unsetVirgaAction, unsetInclinatumAction, removeHandler, deleteButtonHandler } from './SelectOptions';
+import { removeHandler, deleteButtonHandler } from './SelectOptions';
 
 /**
  * The NeonView parent to access editor actions.
@@ -88,9 +88,9 @@ export function initGroupingListeners (): void {
       const elementIds = getIds();
       
       const editorAction: EditorAction = {
-        'action': 'toggleLigature',
-        'param': {
-          'elementIds': elementIds
+        action: 'toggleLigature',
+        param: {
+          elementIds: elementIds
         }
       };
       neonView.edit(editorAction, neonView.view.getCurrentPageURI()).then((result) => {
@@ -109,56 +109,56 @@ export function initGroupingListeners (): void {
     document.getElementById('toggle-link').addEventListener('click', () => {
       const elementIds = getIds();
       const chainAction: EditorAction = {
-        'action': 'chain',
-        'param': []
+        action: 'chain',
+        param: []
       };
       const param = new Array<EditorAction>();
       if (document.getElementById(elementIds[0]).getAttribute('mei:precedes')) {
         param.push({
-          'action': 'set',
-          'param': {
-            'elementId': elementIds[0],
-            'attrType': 'precedes',
-            'attrValue': ''
+          action: 'set',
+          param: {
+            elementId: elementIds[0],
+            attrType: 'precedes',
+            attrValue: ''
           }
         });
         param.push({
-          'action': 'set',
-          'param': {
-            'elementId': elementIds[1],
-            'attrType': 'follows',
-            'attrValue': ''
+          action: 'set',
+          param: {
+            elementId: elementIds[1],
+            attrType: 'follows',
+            attrValue: ''
           }
         });
         param.push({
-          'action': 'setText',
-          'param': {
-            'elementId': elementIds[1],
-            'text': ''
+          action: 'setText',
+          param: {
+            elementId: elementIds[1],
+            text: ''
           }
         });
       } else if (document.getElementById(elementIds[0]).getAttribute('mei:follows')) {
         param.push({
-          'action': 'set',
-          'param': {
-            'elementId': elementIds[0],
-            'attrType': 'follows',
-            'attrValue': ''
+          action: 'set',
+          param: {
+            elementId: elementIds[0],
+            attrType: 'follows',
+            attrValue: ''
           }
         });
         param.push({
-          'action': 'set',
-          'param': {
-            'elementId': elementIds[1],
-            'attrType': 'precedes',
-            'attrValue': ''
+          action: 'set',
+          param: {
+            elementId: elementIds[1],
+            attrType: 'precedes',
+            attrValue: ''
           }
         });
         param.push({
-          'action': 'setText',
-          'param': {
-            'elementId': elementIds[0],
-            'text': ''
+          action: 'setText',
+          param: {
+            elementId: elementIds[0],
+            text: ''
           }
         });
       } else {
@@ -180,28 +180,28 @@ export function initGroupingListeners (): void {
         }
 
         param.push({
-          'action': 'set',
-          'param': {
-            'elementId': firstSyllable.id,
-            'attrType': 'precedes',
-            'attrValue': '#' + secondSyllable.id
+          action: 'set',
+          param: {
+            elementId: firstSyllable.id,
+            attrType: 'precedes',
+            attrValue: '#' + secondSyllable.id
           }
         });
         param.push({
-          'action': 'set',
-          'param': {
-            'elementId': secondSyllable.id,
-            'attrType': 'follows',
-            'attrValue': '#' + firstSyllable.id
+          action: 'set',
+          param: {
+            elementId: secondSyllable.id,
+            attrType: 'follows',
+            attrValue: '#' + firstSyllable.id
           }
         });
         // Delete syl on second syllable
         const syl = secondSyllable.querySelector('.syl');
         if (syl !== null) {
           param.push({
-            'action': 'remove',
-            'param': {
-              'elementId': syl.id
+            action: 'remove',
+            param: {
+              elementId: syl.id
             }
           });
         }
@@ -228,10 +228,10 @@ export function initGroupingListeners (): void {
  */
 function groupingAction (action: string, groupType: string, elementIds: string[]): void {
   const editorAction: EditorAction = {
-    'action': action,
-    'param': {
-      'groupType': groupType,
-      'elementIds': elementIds
+    action: action,
+    param: {
+      groupType: groupType,
+      elementIds: elementIds
     }
   };
   neonView.edit(editorAction, neonView.view.getCurrentPageURI()).then((result) => {

--- a/src/SquareEdit/InsertHandler.ts
+++ b/src/SquareEdit/InsertHandler.ts
@@ -36,24 +36,24 @@ class InsertHandler {
         break;
       case 'diamond':
         this.type = 'nc';
-        this.attributes = { 'tilt': 'se'};
+        this.attributes = { tilt: 'se' };
         break;
       case 'virga':
         this.type = 'nc';
-        this.attributes = { 'tilt': 's'};
+        this.attributes = { tilt: 's' };
         break;
       //there are multiple possible liquescent combinations
       case 'liquescentA':
         this.type = 'nc';
-        this.attributes = { 'curve': 'a'};
+        this.attributes = { curve: 'a' };
         break;
       case 'liquescentC':
         this.type = 'nc';
-        this.attributes = { 'curve': 'c'};
+        this.attributes = { curve: 'c' };
         break;
       case 'virgaReversed':
         this.type = 'nc';
-        this.attributes = { 'tilt': 'n' };
+        this.attributes = { tilt: 'n' };
         break;
       case 'pes':
       case 'clivis':
@@ -66,12 +66,12 @@ class InsertHandler {
           buttonId.charAt(0).toUpperCase() + buttonId.slice(1)
         );
         this.type = 'grouping';
-        this.attributes = { 'contour': contour };
+        this.attributes = { contour: contour };
         break;
       case 'cClef':
       case 'fClef':
         this.type = 'clef';
-        this.attributes = { 'shape': buttonId.charAt(0).toUpperCase() };
+        this.attributes = { shape: buttonId.charAt(0).toUpperCase() };
         break;
       case 'custos':
         this.type = 'custos';
@@ -79,7 +79,7 @@ class InsertHandler {
         break;
       case 'divLineMaxima':
         this.type = 'divLine';
-        this.attributes = { 'form': 'maxima' };
+        this.attributes = { form: 'maxima' };
         break;
       case 'staff':
         this.type = 'staff';
@@ -87,11 +87,11 @@ class InsertHandler {
         break;
       case 'flat':
         this.type = 'accid';
-        this.attributes = { 'accid': 'f' };
+        this.attributes = { accid: 'f' };
         break;
       case 'natural':
         this.type = 'accid';
-        this.attributes = { 'accid': 'n' };
+        this.attributes = { accid: 'n' };
         break;
       default:
         this.type = '';
@@ -216,12 +216,12 @@ class InsertHandler {
     const cursorpt = pt.matrixTransform(transformMatrix.inverse());
 
     const editorAction: EditorAction = {
-      'action': 'insert',
-      'param': {
-        'elementType': this.type,
-        'staffId': 'auto',
-        'ulx': cursorpt.x,
-        'uly': cursorpt.y
+      action: 'insert',
+      param: {
+        elementType: this.type,
+        staffId: 'auto',
+        ulx: cursorpt.x,
+        uly: cursorpt.y
       }
     };
 
@@ -269,14 +269,14 @@ class InsertHandler {
       }
       document.getElementById('staff-circle').remove();
       const action: EditorAction = {
-        'action': 'insert',
-        'param': {
-          'elementType': 'staff',
-          'staffId': 'auto',
-          'ulx': ul.x,
-          'uly': ul.y,
-          'lrx': lr.x,
-          'lry': lr.y
+        action: 'insert',
+        param: {
+          elementType: 'staff',
+          staffId: 'auto',
+          ulx: ul.x,
+          uly: ul.y,
+          lrx: lr.x,
+          lry: lr.y
         }
       };
 

--- a/src/SquareEdit/NeumeTools.ts
+++ b/src/SquareEdit/NeumeTools.ts
@@ -48,10 +48,10 @@ export class SplitNeumeHandler {
     const ncId = nc.id;
 
     const editorAction: EditorAction = {
-      'action': 'splitNeume',
-      'param': {
-        'elementId': id,
-        'ncId': ncId
+      action: 'splitNeume',
+      param: {
+        elementId: id,
+        ncId: ncId
       }
     };
 

--- a/src/SquareEdit/SelectOptions.ts
+++ b/src/SquareEdit/SelectOptions.ts
@@ -26,11 +26,11 @@ export function initNeonView (view: NeonView): void {
  */
 export function unsetInclinatumAction (id: string): EditorAction {
   return {
-    'action': 'set',
-    'param': {
-      'elementId': id,
-      'attrType': 'tilt',
-      'attrValue': ''
+    action: 'set',
+    param: {
+      elementId: id,
+      attrType: 'tilt',
+      attrValue: ''
     }
   };
 }
@@ -41,11 +41,11 @@ export function unsetInclinatumAction (id: string): EditorAction {
  */
 export function unsetVirgaAction (id: string): EditorAction {
   return {
-    'action': 'set',
-    'param': {
-      'elementId': id,
-      'attrType': 'tilt',
-      'attrValue': ''
+    action: 'set',
+    param: {
+      elementId: id,
+      attrType: 'tilt',
+      attrValue: ''
     }
   };
 }
@@ -54,13 +54,13 @@ export function unsetVirgaAction (id: string): EditorAction {
  * @param id - The id of the neume component.
  * @returns An action that unsets the reversed virga parameter of a neume component.
  */
- export function unsetVirgaReversedAction (id: string): EditorAction {
+export function unsetVirgaReversedAction (id: string): EditorAction {
   return {
-    'action': 'set',
-    'param': {
-      'elementId': id,
-      'attrType': 'tilt',
-      'attrValue': ''
+    action: 'set',
+    param: {
+      elementId: id,
+      attrType: 'tilt',
+      attrValue: ''
     }
   };
 }
@@ -69,13 +69,13 @@ export function unsetVirgaAction (id: string): EditorAction {
  * @param id - The id of the neume component.
  * @returns An action that unsets the liquescent_clockwise parameter of a neume component.
  */
- export function unsetLiquescentClockwiseAction (id: string): EditorAction {
+export function unsetLiquescentClockwiseAction (id: string): EditorAction {
   return {
-    'action': 'set',
-    'param': {
-      'elementId': id,
-      'attrType': 'curve',
-      'attrValue': ''
+    action: 'set',
+    param: {
+      elementId: id,
+      attrType: 'curve',
+      attrValue: ''
     }
   };
 }
@@ -84,16 +84,34 @@ export function unsetVirgaAction (id: string): EditorAction {
  * @param id - The id of the neume component.
  * @returns An action that unsets the liquescent_anticlockwise parameter of a neume component.
  */
- export function unsetLiquescentAnticlockwiseAction (id: string): EditorAction {
+export function unsetLiquescentAnticlockwiseAction (id: string): EditorAction {
   return {
-    'action': 'set',
-    'param': {
-      'elementId': id,
-      'attrType': 'curve',
-      'attrValue': ''
+    action: 'set',
+    param: {
+      elementId: id,
+      attrType: 'curve',
+      attrValue: ''
     }
   };
 }
+
+/** Event handler for delete button press. */
+export function deleteButtonHandler (evt: KeyboardEvent): void {
+  if (evt.key === 'd' || evt.key === 'Backspace') { removeHandler(); evt.preventDefault(); }
+}
+
+/**
+ * End the extra options menu.
+ */
+export function endOptionsSelection (): void {
+  try {
+    const moreEdit = document.getElementById('moreEdit');
+    moreEdit.innerHTML = '';
+    moreEdit.classList.add('is-invisible');
+  } catch (e) {}
+  document.body.removeEventListener('keydown', deleteButtonHandler);
+}
+
 
 /**
  * Function to handle removing elements
@@ -113,16 +131,16 @@ export function removeHandler (): void {
     }
     toRemove.push(
       {
-        'action': 'remove',
-        'param': {
-          'elementId': elem.id
+        action: 'remove',
+        param: {
+          elementId: elem.id
         }
       }
     );
   });
   const chainAction: EditorAction = {
-    'action': 'chain',
-    'param': toRemove
+    action: 'chain',
+    param: toRemove
   };
   endOptionsSelection();
   neonView.edit(chainAction, neonView.view.getCurrentPageURI()).then(() => { neonView.updateForCurrentPage(); });
@@ -137,16 +155,16 @@ export function changeStaffHandler(): void {
   selected.forEach(elem => {
     toChange.push(
       {
-        'action': 'changeStaff',
-        'param': {
-          'elementId': elem.id
+        action: 'changeStaff',
+        param: {
+          elementId: elem.id
         }
       }
     );
   });
   const chainAction: EditorAction = {
-    'action': 'chain',
-    'param': toChange
+    action: 'chain',
+    param: toChange
   };
   endOptionsSelection();
   neonView.edit(chainAction, neonView.view.getCurrentPageURI()).then(() => { neonView.updateForCurrentPage(); });
@@ -162,16 +180,16 @@ export function insertToSyllableHandler(): void {
   selected.forEach(elem => {
     toInsert.push(
       {
-        'action': 'insertToSyllable',
-        'param': {
-          'elementId': elem.id
+        action: 'insertToSyllable',
+        param: {
+          elementId: elem.id
         }
       }
     );
   });
   const chainAction: EditorAction = {
-    'action': 'chain',
-    'param': toInsert
+    action: 'chain',
+    param: toInsert
   };
   neonView.edit(chainAction, neonView.view.getCurrentPageURI()).then((result) => { 
     if (result) {
@@ -225,7 +243,7 @@ export function triggerNcActions (nc: SVGGraphicsElement): void {
       const unsetVirgaReversed = unsetVirgaReversedAction(nc.id);
       const unsetLiquescentClockwise = unsetLiquescentClockwiseAction(nc.id);
       const unsetLiquescentAnticlockwise = unsetLiquescentAnticlockwiseAction(nc.id);
-      neonView.edit({ 'action': 'chain', 'param': [ unsetInclinatum, unsetVirga, unsetVirgaReversed, unsetLiquescentClockwise, unsetLiquescentAnticlockwise ] }, neonView.view.getCurrentPageURI()).then((result) => {
+      neonView.edit({ action: 'chain', param: [ unsetInclinatum, unsetVirga, unsetVirgaReversed, unsetLiquescentClockwise, unsetLiquescentAnticlockwise ] }, neonView.view.getCurrentPageURI()).then((result) => {
         if (result) {
           Notification.queueNotification('Shape Changed');
         } else {
@@ -243,14 +261,14 @@ export function triggerNcActions (nc: SVGGraphicsElement): void {
       const unsetLiquescentClockwise = unsetLiquescentClockwiseAction(nc.id);
       const unsetLiquescentAnticlockwise = unsetLiquescentAnticlockwiseAction(nc.id);
       const setInclinatum = {
-        'action': 'set',
-        'param': {
-          'elementId': nc.id,
-          'attrType': 'tilt',
-          'attrValue': 'se'
+        action: 'set',
+        param: {
+          elementId: nc.id,
+          attrType: 'tilt',
+          attrValue: 'se'
         }
       };
-      neonView.edit({ 'action': 'chain', 'param': [ unsetVirga, unsetVirgaReversed, unsetLiquescentClockwise, unsetLiquescentAnticlockwise, setInclinatum ] } , neonView.view.getCurrentPageURI()).then((result) => {
+      neonView.edit({ action: 'chain', param: [ unsetVirga, unsetVirgaReversed, unsetLiquescentClockwise, unsetLiquescentAnticlockwise, setInclinatum ] } , neonView.view.getCurrentPageURI()).then((result) => {
         if (result) {
           Notification.queueNotification('Shape Changed');
         } else {
@@ -268,14 +286,14 @@ export function triggerNcActions (nc: SVGGraphicsElement): void {
       const unsetLiquescentClockwise = unsetLiquescentClockwiseAction(nc.id);
       const unsetLiquescentAnticlockwise = unsetLiquescentAnticlockwiseAction(nc.id);
       const setVirga = {
-        'action': 'set',
-        'param': {
-          'elementId': nc.id,
-          'attrType': 'tilt',
-          'attrValue': 's'
+        action: 'set',
+        param: {
+          elementId: nc.id,
+          attrType: 'tilt',
+          attrValue: 's'
         }
       };
-      neonView.edit({ 'action': 'chain', 'param': [ unsetVirgaReversed, unsetInclinatum, unsetLiquescentClockwise, unsetLiquescentAnticlockwise, setVirga ] }, neonView.view.getCurrentPageURI()).then((result) => {
+      neonView.edit({ action: 'chain', param: [ unsetVirgaReversed, unsetInclinatum, unsetLiquescentClockwise, unsetLiquescentAnticlockwise, setVirga ] }, neonView.view.getCurrentPageURI()).then((result) => {
         if (result) {
           Notification.queueNotification('Shape Changed');
         } else {
@@ -286,21 +304,21 @@ export function triggerNcActions (nc: SVGGraphicsElement): void {
       });
     });
 
-    document.querySelector('#VirgaReversed.dropdown-item')
+  document.querySelector('#VirgaReversed.dropdown-item')
     .addEventListener('click', () => {
       const unsetInclinatum = unsetInclinatumAction(nc.id);
       const unsetVirga = unsetVirgaAction(nc.id);
       const unsetLiquescentClockwise = unsetLiquescentClockwiseAction(nc.id);
       const unsetLiquescentAnticlockwise = unsetLiquescentAnticlockwiseAction(nc.id);
       const setVirgaReversed = {
-        'action': 'set',
-        'param': {
-          'elementId': nc.id,
-          'attrType': 'tilt',
-          'attrValue': 'n'
+        action: 'set',
+        param: {
+          elementId: nc.id,
+          attrType: 'tilt',
+          attrValue: 'n'
         }
       };
-      neonView.edit({ 'action': 'chain', 'param': [ unsetInclinatum, unsetVirga, unsetLiquescentClockwise, unsetLiquescentAnticlockwise, setVirgaReversed ] }, neonView.view.getCurrentPageURI()).then((result) => {
+      neonView.edit({ action: 'chain', param: [ unsetInclinatum, unsetVirga, unsetLiquescentClockwise, unsetLiquescentAnticlockwise, setVirgaReversed ] }, neonView.view.getCurrentPageURI()).then((result) => {
         if (result) {
           Notification.queueNotification('Shape Changed');
         } else {
@@ -312,54 +330,54 @@ export function triggerNcActions (nc: SVGGraphicsElement): void {
     });
 
   document.querySelector('#LiquescentClockwise.dropdown-item')
-  .addEventListener('click', () => {
-    const unsetInclinatum = unsetInclinatumAction(nc.id);
-    const unsetVirga = unsetVirgaAction(nc.id);
-    const unsetVirgaReversed = unsetVirgaReversedAction(nc.id);
-    const unsetLiquescentAnticlockwise = unsetLiquescentAnticlockwiseAction(nc.id);
-    const setLiquescentClockwise = {
-      'action': 'set',
-      'param': {
-        'elementId': nc.id,
-        'attrType': 'curve',
-        'attrValue': 'c'
-      }
-    };
-    neonView.edit({ 'action': 'chain', 'param': [ unsetInclinatum, unsetVirga, unsetVirgaReversed, unsetLiquescentAnticlockwise, setLiquescentClockwise ] }, neonView.view.getCurrentPageURI()).then((result) => {
-      if (result) {
-        Notification.queueNotification('Shape Changed');
-      } else {
-        Notification.queueNotification('Shape Change Failed');
-      }
-      endOptionsSelection();
-      neonView.updateForCurrentPage();
-    });
-  });  
+    .addEventListener('click', () => {
+      const unsetInclinatum = unsetInclinatumAction(nc.id);
+      const unsetVirga = unsetVirgaAction(nc.id);
+      const unsetVirgaReversed = unsetVirgaReversedAction(nc.id);
+      const unsetLiquescentAnticlockwise = unsetLiquescentAnticlockwiseAction(nc.id);
+      const setLiquescentClockwise = {
+        action: 'set',
+        param: {
+          elementId: nc.id,
+          attrType: 'curve',
+          attrValue: 'c'
+        }
+      };
+      neonView.edit({ action: 'chain', param: [ unsetInclinatum, unsetVirga, unsetVirgaReversed, unsetLiquescentAnticlockwise, setLiquescentClockwise ] }, neonView.view.getCurrentPageURI()).then((result) => {
+        if (result) {
+          Notification.queueNotification('Shape Changed');
+        } else {
+          Notification.queueNotification('Shape Change Failed');
+        }
+        endOptionsSelection();
+        neonView.updateForCurrentPage();
+      });
+    });  
 
   document.querySelector('#LiquescentAnticlockwise.dropdown-item')
-  .addEventListener('click', () => {
-    const unsetInclinatum = unsetInclinatumAction(nc.id);
-    const unsetVirga = unsetVirgaAction(nc.id);
-    const unsetVirgaReversed = unsetVirgaReversedAction(nc.id);
-    const unsetLiquescentClockwise = unsetLiquescentClockwiseAction(nc.id);
-    const setLiquescentAnticlockwise = {
-      'action': 'set',
-      'param': {
-        'elementId': nc.id,
-        'attrType': 'curve',
-        'attrValue': 'a'
-      }
-    };
-    neonView.edit({ 'action': 'chain', 'param': [ unsetInclinatum, unsetVirga, unsetVirgaReversed, unsetLiquescentClockwise, setLiquescentAnticlockwise ] }, neonView.view.getCurrentPageURI()).then((result) => {
-      if (result) {
-        Notification.queueNotification('Shape Changed');
-      } else {
-        Notification.queueNotification('Shape Change Failed');
-      }
-      endOptionsSelection();
-      neonView.updateForCurrentPage();
-    });
-  });  
+    .addEventListener('click', () => {
+      const unsetInclinatum = unsetInclinatumAction(nc.id);
+      const unsetVirga = unsetVirgaAction(nc.id);
+      const unsetVirgaReversed = unsetVirgaReversedAction(nc.id);
+      const unsetLiquescentClockwise = unsetLiquescentClockwiseAction(nc.id);
+      const setLiquescentAnticlockwise = {
+        action: 'set',
+        param: {
+          elementId: nc.id,
+          attrType: 'curve',
+          attrValue: 'a'
+        }
+      };
+      neonView.edit({ action: 'chain', param: [ unsetInclinatum, unsetVirga, unsetVirgaReversed, unsetLiquescentClockwise, setLiquescentAnticlockwise ] }, neonView.view.getCurrentPageURI()).then((result) => {
+        if (result) {
+          Notification.queueNotification('Shape Changed');
+        } else {
+          Notification.queueNotification('Shape Change Failed');
+        }
+        endOptionsSelection();
+        neonView.updateForCurrentPage();
+      });
+    });  
 
   try {
     const del = document.getElementById('delete');
@@ -386,7 +404,7 @@ export function triggerNeumeActions (): void {
     extraEdit.classList.remove('is-invisible');
     extraEdit.innerHTML = Contents.neumeActionContents;
   } catch (e) {}
-    const neume = document.querySelectorAll('.selected');
+  const neume = document.querySelectorAll('.selected');
   if (neume.length !== 1) {
     console.warn('More than one neume selected! Cannot trigger Neume ClickSelect actions.');
     return;
@@ -407,82 +425,82 @@ export function triggerNeumeActions (): void {
     });
 
   document.querySelector('#Pes.dropdown-item')
-  .addEventListener('click', (e) => {
-    const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
-    triggerChangeGroup(contour); 
-  }); 
+    .addEventListener('click', (e) => {
+      const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
+      triggerChangeGroup(contour); 
+    }); 
   document.querySelector('#PesSubpunctis.dropdown-item')
-  .addEventListener('click', (e) => {
-    const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
-    triggerChangeGroup(contour); 
-  }); 
+    .addEventListener('click', (e) => {
+      const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
+      triggerChangeGroup(contour); 
+    }); 
   document.querySelector('#Clivis.dropdown-item')
-  .addEventListener('click', (e) => {
-    const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
-    triggerChangeGroup(contour); 
-  }); 
+    .addEventListener('click', (e) => {
+      const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
+      triggerChangeGroup(contour); 
+    }); 
   document.querySelector('#Scandicus.dropdown-item')
-  .addEventListener('click', (e) => {
-    const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
-    triggerChangeGroup(contour); 
-  }); 
+    .addEventListener('click', (e) => {
+      const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
+      triggerChangeGroup(contour); 
+    }); 
   document.querySelector('#ScandicusFlexus.dropdown-item')
-  .addEventListener('click', (e) => {
-    const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
-    triggerChangeGroup(contour); 
-  }); 
+    .addEventListener('click', (e) => {
+      const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
+      triggerChangeGroup(contour); 
+    }); 
   document.querySelector('#ScandicusSubpunctis.dropdown-item')
-  .addEventListener('click', (e) => {
-    const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
-    triggerChangeGroup(contour); 
-  }); 
+    .addEventListener('click', (e) => {
+      const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
+      triggerChangeGroup(contour); 
+    }); 
   document.querySelector('#Climacus.dropdown-item')
-  .addEventListener('click', (e) => {
-    const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
-    triggerChangeGroup(contour); 
-  }); 
+    .addEventListener('click', (e) => {
+      const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
+      triggerChangeGroup(contour); 
+    }); 
   document.querySelector('#ClimacusResupinus.dropdown-item')
-  .addEventListener('click', (e) => {
-    const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
-    triggerChangeGroup(contour); 
-  }); 
+    .addEventListener('click', (e) => {
+      const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
+      triggerChangeGroup(contour); 
+    }); 
   document.querySelector('#Torculus.dropdown-item')
-  .addEventListener('click', (e) => {
-    const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
-    triggerChangeGroup(contour); 
-  }); 
+    .addEventListener('click', (e) => {
+      const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
+      triggerChangeGroup(contour); 
+    }); 
   document.querySelector('#TorculusResupinus.dropdown-item')
-  .addEventListener('click', (e) => {
-    const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
-    triggerChangeGroup(contour); 
-  }); 
+    .addEventListener('click', (e) => {
+      const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
+      triggerChangeGroup(contour); 
+    }); 
   document.querySelector('#Porrectus.dropdown-item')
-  .addEventListener('click', (e) => {
-    const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
-    triggerChangeGroup(contour); 
-  }); 
+    .addEventListener('click', (e) => {
+      const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
+      triggerChangeGroup(contour); 
+    }); 
   document.querySelector('#PorrectusFlexus.dropdown-item')
-  .addEventListener('click', (e) => {
-    const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
-    triggerChangeGroup(contour); 
-  }); 
+    .addEventListener('click', (e) => {
+      const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
+      triggerChangeGroup(contour); 
+    }); 
   document.querySelector('#PorrectusSubpunctis.dropdown-item')
-  .addEventListener('click', (e) => {
-    const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
-    triggerChangeGroup(contour); 
-  }); 
+    .addEventListener('click', (e) => {
+      const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
+      triggerChangeGroup(contour); 
+    }); 
   document.querySelector('#Pressus.dropdown-item')
-  .addEventListener('click', (e) => {
-    const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
-    triggerChangeGroup(contour); 
-  }); 
+    .addEventListener('click', (e) => {
+      const contour = neonView.info.getContourByValue((e.target as HTMLElement).id);
+      triggerChangeGroup(contour); 
+    }); 
 
   function triggerChangeGroup (contour): void {
     const changeGroupingAction: EditorAction = {
-      'action': 'changeGroup',
-      'param': {
-        'elementId': neume[0].id,
-        'contour': contour
+      action: 'changeGroup',
+      param: {
+        elementId: neume[0].id,
+        contour: contour
       }
     };
     neonView.edit(changeGroupingAction, neonView.view.getCurrentPageURI()).then((result) => {
@@ -561,10 +579,10 @@ export function triggerClefActions (clef: SVGGraphicsElement): void {
   document.querySelector('#CClef.dropdown-item')
     .addEventListener('click', () => {
       const setCClef: EditorAction = {
-        'action': 'setClef',
-        'param': {
-          'elementId': clef.id,
-          'shape': 'C'
+        action: 'setClef',
+        param: {
+          elementId: clef.id,
+          shape: 'C'
         }
       };
       neonView.edit(setCClef, neonView.view.getCurrentPageURI()).then((result) => {
@@ -580,10 +598,10 @@ export function triggerClefActions (clef: SVGGraphicsElement): void {
   document.querySelector('#FClef.dropdown-item')
     .addEventListener('click', () => {
       const setFClef: EditorAction = {
-        'action': 'setClef',
-        'param': {
-          'elementId': clef.id,
-          'shape': 'F'
+        action: 'setClef',
+        param: {
+          elementId: clef.id,
+          shape: 'F'
         }
       };
       neonView.edit(setFClef, neonView.view.getCurrentPageURI()).then((result) => {
@@ -663,11 +681,11 @@ export function triggerAccidActions (accid: SVGGraphicsElement): void {
   document.querySelector('#ChangeToFlat.dropdown-item')
     .addEventListener('click', () => {
       const changeToFlat: EditorAction = {
-        'action': 'set',
-        'param': {
-          'elementId': accid.id,
-          'attrType': 'accid',
-          'attrValue': 'f'
+        action: 'set',
+        param: {
+          elementId: accid.id,
+          attrType: 'accid',
+          attrValue: 'f'
         }
       };
       neonView.edit(changeToFlat, neonView.view.getCurrentPageURI()).then((result) => {
@@ -683,11 +701,11 @@ export function triggerAccidActions (accid: SVGGraphicsElement): void {
   document.querySelector('#ChangeToNatural.dropdown-item')
     .addEventListener('click', () => {
       const changeToNatural: EditorAction = {
-        'action': 'set',
-        'param': {
-          'elementId': accid.id,
-          'attrType': 'accid',
-          'attrValue': 'n'
+        action: 'set',
+        param: {
+          elementId: accid.id,
+          attrType: 'accid',
+          attrValue: 'n'
         }
       };
       neonView.edit(changeToNatural, neonView.view.getCurrentPageURI()).then((result) => {
@@ -759,9 +777,9 @@ export function triggerStaffActions (): void {
         elementIds.push(staff.id);
       });
       const editorAction: EditorAction = {
-        'action': 'merge',
-        'param': {
-          'elementIds': elementIds
+        action: 'merge',
+        param: {
+          elementIds: elementIds
         }
       };
       neonView.edit(editorAction, neonView.view.getCurrentPageURI()).then((result) => {
@@ -811,21 +829,22 @@ export function triggerSplitActions (): void {
   document.getElementById('reset-rotate')
     .addEventListener('click', () => {
       const staff = document.querySelector('.staff.selected') as SVGElement;
-      const rect = staff.querySelector('#resizeRect');
-      const co = rect.getAttribute('points').split(' ');
-      const dy = parseInt(co[0].split(',')[1]) - parseInt(co[1].split(',')[1]);
-      let points = getStaffBBox(staff as SVGGElement);
-      let y_change = Math.tan(points.rotate)*(points.lrx - points.ulx);
+      // Unused variables:
+      // const rect = staff.querySelector('#resizeRect');
+      // const co = rect.getAttribute('points').split(' ');
+      // const dy = parseInt(co[0].split(',')[1]) - parseInt(co[1].split(',')[1]);
+      const points = getStaffBBox(staff as SVGGElement);
+      const y_change = Math.tan(points.rotate)*(points.lrx - points.ulx);
       if (staff !== null) {
         const editorAction: EditorAction = {
-          'action': 'resizeRotate',
-          'param': {
-            'elementId': staff.id,
-            "ulx": points.ulx,
-            "uly": points.rotate > 0 ? points.uly + y_change/2 : points.uly - y_change/2,
-            "lrx": points.lrx,
-            "lry": points.rotate > 0 ? points.lry - y_change/2 : points.lry + y_change/2,
-            "rotate": 0
+          action: 'resizeRotate',
+          param: {
+            elementId: staff.id,
+            ulx: points.ulx,
+            uly: points.rotate > 0 ? points.uly + y_change/2 : points.uly - y_change/2,
+            lrx: points.lrx,
+            lry: points.rotate > 0 ? points.lry - y_change/2 : points.lry + y_change/2,
+            rotate: 0
           }
         };
         neonView.edit(editorAction, neonView.view.getCurrentPageURI()).then(async (result) => {
@@ -892,27 +911,10 @@ export function triggerDefaultActions (): void {
 }
 
 /**
- * End the extra options menu.
- */
-export function endOptionsSelection (): void {
-  try {
-    const moreEdit = document.getElementById('moreEdit');
-    moreEdit.innerHTML = '';
-    moreEdit.classList.add('is-invisible');
-  } catch (e) {}
-  document.body.removeEventListener('keydown', deleteButtonHandler);
-}
-
-/**
  * Initialize extra dropdown options.
  */
 function initOptionsListeners (): void {
   document.getElementById('drop_select').addEventListener('click', function () {
     this.classList.toggle('is-active');
   });
-}
-
-/** Event handler for delete button press. */
-export function deleteButtonHandler (evt: KeyboardEvent): void {
-  if (evt.key === 'd' || evt.key === 'Backspace') { removeHandler(); evt.preventDefault(); }
 }

--- a/src/SquareEdit/StaffTools.ts
+++ b/src/SquareEdit/StaffTools.ts
@@ -57,10 +57,10 @@ export class SplitStaffHandler {
     // TODO
 
     const editorAction: EditorAction = {
-      'action': 'split',
-      'param': {
-        'elementId': id,
-        'x': cursorPt.x
+      action: 'split',
+      param: {
+        elementId: id,
+        x: cursorPt.x
       }
     };
 

--- a/src/TextEditMode.ts
+++ b/src/TextEditMode.ts
@@ -162,10 +162,10 @@ export default class TextEditMode implements TextEditInterface {
     const corrected = window.prompt('', orig);
     if (corrected !== null && corrected !== orig) {
       const editorAction = {
-        'action': 'setText',
-        'param': {
-          'elementId': [...span.classList.entries()].filter(e => e[1] !== 'text-select')[0][1],
-          'text': corrected
+        action: 'setText',
+        param: {
+          elementId: [...span.classList.entries()].filter(e => e[1] !== 'text-select')[0][1],
+          text: corrected
         }
       };
       this.neonView.edit(editorAction, this.neonView.view.getCurrentPageURI()).then((response) => {

--- a/src/Warnings.ts
+++ b/src/Warnings.ts
@@ -3,7 +3,7 @@
 /**
  * Warn when grouped neume components form an unrecognized neume.
  */
-export function groupingNotRecognized () {
+export function groupingNotRecognized (): void {
   if (!(window.confirm('Neon does not recognize this neume grouping. Would you like to create a compound neume?'))) {
     document.getElementById('undo').click();
   }

--- a/src/utils/Color.ts
+++ b/src/utils/Color.ts
@@ -42,7 +42,7 @@ export function unhighlight(staff?: SVGGElement): void {
           rect.closest('.staff').classList.contains('selected') ||
           rect.closest('.syl').classList.contains('selected')
           // rect.closest('.layer').classList.contains('selected')
-          ){
+        ){
           rect.style.fill = 'red';
         } else {
           rect.style.fill = 'blue';
@@ -200,7 +200,7 @@ export function setGroupingHighlight(grouping: string): void {
   let groups;
 
   if (grouping == 'layer') {
-    groups = document.querySelectorAll(".accid, .clef, .custos, .divLine");
+    groups = document.querySelectorAll('.accid, .clef, .custos, .divLine');
   }
   else {
     groups = document.getElementsByClassName(grouping) as HTMLCollectionOf<HTMLElement>;

--- a/src/utils/ConvertMei.ts
+++ b/src/utils/ConvertMei.ts
@@ -95,6 +95,19 @@ export function convertStaffToSb(staffBasedMei: string): string {
   return vkbeautify.xml(serializer.serializeToString(meiDoc));
 }
 
+export function getSyllableText (syllable: Element): string {
+  const syl = syllable.getElementsByTagName('syl')[0].childNodes[0];
+  let sylText: string;
+  if (syl) {
+    sylText = syl.nodeValue;
+  }
+  else {
+    sylText = 'null';
+  }
+
+  return sylText;
+}
+
 export function convertSbToStaff(sbBasedMei: string): string {
   const parser = new DOMParser();
   const meiDoc = parser.parseFromString(sbBasedMei, 'text/xml');
@@ -219,7 +232,7 @@ export function convertSbToStaff(sbBasedMei: string): string {
 
     // Check syllables that contains @precedes or @follows
     // Update syllable arrays for each syllable
-    let newSyllables = Array.from(mei.getElementsByTagName('syllable'));
+    const newSyllables = Array.from(mei.getElementsByTagName('syllable'));
     // For each toggle-linked syllable
     // Set @precedes and @follows to make sure pointing to the correct syllable
     if (syllable.hasAttribute('precedes')) {
@@ -267,15 +280,3 @@ export function convertSbToStaff(sbBasedMei: string): string {
   return vkbeautify.xml(serializer.serializeToString(meiDoc));
 }
 
-export function getSyllableText (syllable: Element) {
-  const syl = syllable.getElementsByTagName('syl')[0].childNodes[0];
-  let sylText;
-  if (syl) {
-    sylText = syl.nodeValue;
-  }
-  else {
-    sylText = 'null';
-  }
-
-  return sylText;
-}

--- a/src/utils/DragHandler.ts
+++ b/src/utils/DragHandler.ts
@@ -25,6 +25,7 @@ class DragHandler {
   dragInit (): void {
     // Adding listeners
     const dragBehaviour = d3.drag()
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
       .on('start', dragStarted.bind(this))
       .on('drag', this.dragging.bind(this))
       .on('end', this.dragEnded.bind(this));
@@ -84,8 +85,8 @@ class DragHandler {
       paramArray.push(singleAction);
     });
     const editorAction: EditorAction = {
-      'action': 'chain',
-      'param': paramArray
+      action: 'chain',
+      param: paramArray
     };
 
     const xDiff = Math.abs(this.dx);

--- a/src/utils/EditControls.ts
+++ b/src/utils/EditControls.ts
@@ -4,47 +4,6 @@ import { navbarDropdownMenu, undoRedoPanel } from './EditContents';
 import { convertStaffToSb } from './ConvertMei';
 
 /**
- * prepare the edit mode button
- */
-export function prepareEditMode (neonView: NeonView): void {
-  const parent = document.getElementById('dropdown_toggle');
-  const editItem = document.createElement('a');
-  editItem.classList.add('navbar-item');
-  const editButton = document.createElement('button');
-  editButton.classList.add('button');
-  editButton.id = 'edit_mode';
-  editButton.textContent = 'Edit MEI';
-  editItem.appendChild(editButton);
-  parent.appendChild(editItem);
-
-  editButton.addEventListener('click', () => {
-    startEditMode(neonView);
-  });
-}
-
-/**
- * start the basic edit mode features
- * is called when the edit mode button is clicked
- */
-export function startEditMode (neonView: NeonView): void {
-  const parent: HTMLElement = document.getElementById('dropdown_toggle').parentElement;
-  document.getElementById('dropdown_toggle').remove();
-  parent.prepend(navbarDropdownMenu);
-  document.getElementById('undoRedo_controls').innerHTML = undoRedoPanel;
-  initNavbar(neonView);
-  initUndoRedoPanel(neonView);
-
-  const selectionHighlight = document.createElement('a');
-  const divider = document.createElement('hr');
-  divider.classList.add('dropdown-divider');
-  selectionHighlight.classList.add('dropdown-item');
-  selectionHighlight.id = 'highlight-selection';
-  selectionHighlight.textContent = 'By Selection Mode';
-  (document.getElementsByClassName('dropdown-content'))[0].appendChild(divider);
-  (document.getElementsByClassName('dropdown-content'))[0].appendChild(selectionHighlight);
-}
-
-/**
  * Set listener on switching EditMode button to File dropdown in the navbar.
  */
 export function initNavbar (neonView: NeonView): void {
@@ -97,20 +56,6 @@ export function initNavbar (neonView: NeonView): void {
  * Initialize the undo/redo panel
  */
 export function initUndoRedoPanel (neonView: NeonView): void {
-  document.getElementById('undo').addEventListener('click', undoHandler);
-  document.body.addEventListener('keydown', (evt) => {
-    if (evt.key === 'z' && (evt.ctrlKey || evt.metaKey)) {
-      undoHandler();
-    }
-  });
-
-  document.getElementById('redo').addEventListener('click', redoHandler);
-  document.body.addEventListener('keydown', (evt) => {
-    if ((evt.key === 'Z' || (evt.key === 'z' && evt.shiftKey)) && (evt.ctrlKey || evt.metaKey)) {
-      redoHandler();
-    }
-  });
-
   /**
    * Tries to undo an action and update the page if it succeeds.
    */
@@ -136,4 +81,61 @@ export function initUndoRedoPanel (neonView: NeonView): void {
       }
     });
   }
+
+  document.getElementById('undo').addEventListener('click', undoHandler);
+  document.body.addEventListener('keydown', (evt) => {
+    if (evt.key === 'z' && (evt.ctrlKey || evt.metaKey)) {
+      undoHandler();
+    }
+  });
+
+  document.getElementById('redo').addEventListener('click', redoHandler);
+  document.body.addEventListener('keydown', (evt) => {
+    if ((evt.key === 'Z' || (evt.key === 'z' && evt.shiftKey)) && (evt.ctrlKey || evt.metaKey)) {
+      redoHandler();
+    }
+  });
 }
+
+/**
+ * start the basic edit mode features
+ * is called when the edit mode button is clicked
+ */
+export function startEditMode (neonView: NeonView): void {
+  const parent: HTMLElement = document.getElementById('dropdown_toggle').parentElement;
+  document.getElementById('dropdown_toggle').remove();
+  parent.prepend(navbarDropdownMenu);
+  document.getElementById('undoRedo_controls').innerHTML = undoRedoPanel;
+  initNavbar(neonView);
+  initUndoRedoPanel(neonView);
+
+  const selectionHighlight = document.createElement('a');
+  const divider = document.createElement('hr');
+  divider.classList.add('dropdown-divider');
+  selectionHighlight.classList.add('dropdown-item');
+  selectionHighlight.id = 'highlight-selection';
+  selectionHighlight.textContent = 'By Selection Mode';
+  (document.getElementsByClassName('dropdown-content'))[0].appendChild(divider);
+  (document.getElementsByClassName('dropdown-content'))[0].appendChild(selectionHighlight);
+}
+
+/**
+ * prepare the edit mode button
+ */
+export function prepareEditMode (neonView: NeonView): void {
+  const parent = document.getElementById('dropdown_toggle');
+  const editItem = document.createElement('a');
+  editItem.classList.add('navbar-item');
+  const editButton = document.createElement('button');
+  editButton.classList.add('button');
+  editButton.id = 'edit_mode';
+  editButton.textContent = 'Edit MEI';
+  editItem.appendChild(editButton);
+  parent.appendChild(editItem);
+
+  editButton.addEventListener('click', () => {
+    startEditMode(neonView);
+  });
+}
+
+

--- a/src/utils/NeonManifest.ts
+++ b/src/utils/NeonManifest.ts
@@ -1,8 +1,8 @@
 import { NeonManifest } from '../Types';
-const NeonSchema = require('./manifest/NeonSchema.json');
-const NeonContext = require('./manifest/context.json');
-
+import * as NeonSchema from './manifest/NeonSchema.json';
+import * as NeonContext from './manifest/NeonSchema.json';
 import { validate } from 'jsonschema';
+
 /**
  * Check if the provided Neon manifest is parseable.
  * @param {string} manifestString - The Neon manifest as a string.

--- a/src/utils/Notification.ts
+++ b/src/utils/Notification.ts
@@ -10,72 +10,6 @@ let notifying = false;
 const NUMBER_TO_DISPLAY = 3;
 
 /**
- * Add a notification to the queue.
- * @param notification - Notification content.
- */
-export function queueNotification (notification: string): void {
-  const notif = new Notification(notification);
-  notifications.push(notif);
-  if (!notifying || document.getElementById('notification-content').querySelectorAll('.neon-notification').length < NUMBER_TO_DISPLAY) {
-    startNotification();
-  }
-}
-
-/**
- * Start displaying notifications. Called automatically.
- */
-function startNotification (): void {
-  if (notifications.length > 0) {
-    notifying = true;
-    const currentNotification = notifications.pop();
-    displayNotification(currentNotification);
-    currentNotification.setTimeoutId(window.setTimeout(clearOrShowNextNotification, 5000, currentNotification.getId()));
-    document.getElementById(currentNotification.getId()).addEventListener('click', () => {
-      window.clearTimeout(currentNotification.timeoutID);
-      clearOrShowNextNotification(currentNotification.getId());
-    });
-  }
-}
-
-/**
- * Display a notification.
- * @param notification - Notification to display.
- */
-function displayNotification (notification: Notification): void {
-  if (notification.isModeMessage) {
-    if (currentModeMessage === null) {
-      currentModeMessage = notification;
-    } else {
-      window.clearTimeout(currentModeMessage.timeoutID);
-      notifications.push(notification);
-      clearOrShowNextNotification(currentModeMessage.getId());
-      return;
-    }
-  }
-  const notificationContent = document.getElementById('notification-content');
-  notificationContent.innerHTML += '<div class=\'neon-notification\' id=\'' + notification.getId() + '\'>' + notification.message + '</div> ';
-  notificationContent.style.display = '';
-  notification.display();
-}
-
-/**
- * Clear the notifications if no more exist or display another from the queue.
- * @param currentId - The ID of the notification to be cleared.
- */
-function clearOrShowNextNotification (currentId: string): void {
-  document.getElementById(currentId).remove();
-  if (currentModeMessage !== null && currentModeMessage.getId() === currentId) {
-    currentModeMessage = null;
-  }
-  if (notifications.length > 0) {
-    startNotification();
-  } else if (document.querySelectorAll('.neon-notification').length === 0) {
-    document.getElementById('notification-content').style.display = 'none';
-    notifying = false;
-  }
-}
-
-/**
  * A class to manage Neon notifications.
  */
 class Notification {
@@ -113,3 +47,71 @@ class Notification {
     return this.id;
   }
 }
+
+/**
+ * Clear the notifications if no more exist or display another from the queue.
+ * @param currentId - The ID of the notification to be cleared.
+ */
+function clearOrShowNextNotification (currentId: string): void {
+  document.getElementById(currentId).remove();
+  if (currentModeMessage !== null && currentModeMessage.getId() === currentId) {
+    currentModeMessage = null;
+  }
+  if (notifications.length > 0) {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    startNotification();
+  } else if (document.querySelectorAll('.neon-notification').length === 0) {
+    document.getElementById('notification-content').style.display = 'none';
+    notifying = false;
+  }
+}
+
+/**
+ * Display a notification.
+ * @param notification - Notification to display.
+ */
+function displayNotification (notification: Notification): void {
+  if (notification.isModeMessage) {
+    if (currentModeMessage === null) {
+      currentModeMessage = notification;
+    } else {
+      window.clearTimeout(currentModeMessage.timeoutID);
+      notifications.push(notification);
+      clearOrShowNextNotification(currentModeMessage.getId());
+      return;
+    }
+  }
+  const notificationContent = document.getElementById('notification-content');
+  notificationContent.innerHTML += '<div class=\'neon-notification\' id=\'' + notification.getId() + '\'>' + notification.message + '</div> ';
+  notificationContent.style.display = '';
+  notification.display();
+}
+
+/**
+ * Start displaying notifications. Called automatically.
+ */
+function startNotification (): void {
+  if (notifications.length > 0) {
+    notifying = true;
+    const currentNotification = notifications.pop();
+    displayNotification(currentNotification);
+    currentNotification.setTimeoutId(window.setTimeout(clearOrShowNextNotification, 5000, currentNotification.getId()));
+    document.getElementById(currentNotification.getId()).addEventListener('click', () => {
+      window.clearTimeout(currentNotification.timeoutID);
+      clearOrShowNextNotification(currentNotification.getId());
+    });
+  }
+}
+
+/**
+ * Add a notification to the queue.
+ * @param notification - Notification content.
+ */
+export function queueNotification (notification: string): void {
+  const notif = new Notification(notification);
+  notifications.push(notif);
+  if (!notifying || document.getElementById('notification-content').querySelectorAll('.neon-notification').length < NUMBER_TO_DISPLAY) {
+    startNotification();
+  }
+}
+

--- a/src/utils/Select.ts
+++ b/src/utils/Select.ts
@@ -1,7 +1,7 @@
 /** @module utils/Select */
 
 import {
-  unselect, getStaffBBox, selectStaff, selectLayerElement, selectAll, getSelectionType
+  unselect, getStaffBBox, selectStaff, selectAll, getSelectionType
 } from './SelectTools';
 import { resize } from './Resize';
 import NeonView from '../NeonView';
@@ -50,29 +50,6 @@ function isSelByBBox (): boolean {
 }
 
 function stopPropHandler (evt): void { evt.stopPropagation(); }
-
-/**
- * Apply listeners for click selection.
- * @param selector - The CSS selector used to choose where listeners are applied.
- */
-export function clickSelect (selector: string): void {
-  document.querySelectorAll(selector).forEach(sel => {
-    sel.removeEventListener('mousedown', clickHandler);
-    sel.addEventListener('mousedown', clickHandler);
-  });
-
-  // Click away listeners
-  document.body.removeEventListener('keydown', escapeKeyListener);
-  document.body.addEventListener('keydown', escapeKeyListener);
-
-  document.getElementById('container')
-    .addEventListener('contextmenu', (evt) => { evt.preventDefault(); });
-
-  document.querySelectorAll('use,rect,#moreEdit').forEach(sel => {
-    sel.removeEventListener('click', stopPropHandler);
-    sel.addEventListener('click', stopPropHandler);
-  });
-}
 
 /**
  * Handle click events related to element selection.
@@ -249,6 +226,30 @@ function clickHandler (evt: MouseEvent): void {
 }
 
 /**
+ * Apply listeners for click selection.
+ * @param selector - The CSS selector used to choose where listeners are applied.
+ */
+export function clickSelect (selector: string): void {
+  document.querySelectorAll(selector).forEach(sel => {
+    sel.removeEventListener('mousedown', clickHandler);
+    sel.addEventListener('mousedown', clickHandler);
+  });
+
+  // Click away listeners
+  document.body.removeEventListener('keydown', escapeKeyListener);
+  document.body.addEventListener('keydown', escapeKeyListener);
+
+  document.getElementById('container')
+    .addEventListener('contextmenu', (evt) => { evt.preventDefault(); });
+
+  document.querySelectorAll('use,rect,#moreEdit').forEach(sel => {
+    sel.removeEventListener('click', stopPropHandler);
+    sel.addEventListener('click', stopPropHandler);
+  });
+}
+
+
+/**
  * Apply listeners for drag selection.
  * @param selector - The CSS selector used to choose where listeners are applied.
  */
@@ -261,13 +262,43 @@ export function dragSelect (selector: string): void {
   d3.selectAll(selector.replace('.active-page', '').trim())
     .on('.drag', null);
   const canvas = d3.select(selector);
-  const dragSelectAction = d3.drag()
-    .on('start', selStart)
-    .on('drag', selecting)
-    .on('end', selEnd);
-  canvas.call(dragSelectAction);
-  if (dragHandler) {
-    dragHandler.resetTo(dragSelectAction);
+
+  /**
+   * Check if a point is in the bounds of a staff element.
+   * Rotate is not taken into account.
+   */
+  function pointNotInStaff (pt: number[]): boolean {
+    const staves = Array.from(document.getElementsByClassName('staff'));
+    const filtered = staves.filter((staff: SVGGElement) => {
+      const bbox = getStaffBBox(staff);
+      const ulx = bbox.ulx;
+      const uly = bbox.uly;
+      const lrx = bbox.lrx;
+      const lry = bbox.lry;
+      const rotate = bbox.rotate;
+
+      return (pt[0] > ulx && pt[0] < lrx) &&
+        (pt[1] > (uly + (pt[0] - ulx) * Math.tan(rotate))) &&
+        (pt[1] < (lry - (lrx - pt[0]) * Math.tan(rotate)));
+    });
+    return (filtered.length === 0);
+  }
+
+  /**
+     * Create an initial dragging rectangle.
+     * @param ulx - The upper left x-position of the new rectangle.
+     * @param uly - The upper left y-position of the new rectangle.
+     */
+  function initRect (ulx: number, uly: number): void {
+    canvas.append('rect')
+      .attr('x', ulx)
+      .attr('y', uly)
+      .attr('width', 0)
+      .attr('height', 0)
+      .attr('id', 'selectRect')
+      .attr('stroke', 'black')
+      .attr('stroke-width', strokeWidth)
+      .attr('fill', 'none');
   }
 
   function selStart (): void {
@@ -299,24 +330,18 @@ export function dragSelect (selector: string): void {
   }
 
   /**
-   * Check if a point is in the bounds of a staff element.
-   * Rotate is not taken into account.
-   */
-  function pointNotInStaff (pt: number[]): boolean {
-    const staves = Array.from(document.getElementsByClassName('staff'));
-    const filtered = staves.filter((staff: SVGGElement) => {
-      const bbox = getStaffBBox(staff);
-      const ulx = bbox.ulx;
-      const uly = bbox.uly;
-      const lrx = bbox.lrx;
-      const lry = bbox.lry;
-      const rotate = bbox.rotate;
-
-      return (pt[0] > ulx && pt[0] < lrx) &&
-        (pt[1] > (uly + (pt[0] - ulx) * Math.tan(rotate))) &&
-        (pt[1] < (lry - (lrx - pt[0]) * Math.tan(rotate)));
-    });
-    return (filtered.length === 0);
+     * Update the dragging rectangle.
+     * @param newX - The new ulx.
+     * @param newY - The new uly.
+     * @param currentWidth - The width of the rectangle in pixels.
+     * @param currentHeight - The height of the rectangle in pixels.
+     */
+  function updateRect (newX: number, newY: number, currentWidth: number, currentHeight: number): void {
+    d3.select('#selectRect')
+      .attr('x', newX)
+      .attr('y', newY)
+      .attr('width', currentWidth)
+      .attr('height', currentHeight);
   }
 
   function selecting (): void {
@@ -429,35 +454,12 @@ export function dragSelect (selector: string): void {
     panning = false;
   }
 
-  /**
-     * Create an initial dragging rectangle.
-     * @param ulx - The upper left x-position of the new rectangle.
-     * @param uly - The upper left y-position of the new rectangle.
-     */
-  function initRect (ulx: number, uly: number): void {
-    canvas.append('rect')
-      .attr('x', ulx)
-      .attr('y', uly)
-      .attr('width', 0)
-      .attr('height', 0)
-      .attr('id', 'selectRect')
-      .attr('stroke', 'black')
-      .attr('stroke-width', strokeWidth)
-      .attr('fill', 'none');
-  }
-
-  /**
-     * Update the dragging rectangle.
-     * @param newX - The new ulx.
-     * @param newY - The new uly.
-     * @param currentWidth - The width of the rectangle in pixels.
-     * @param currentHeight - The height of the rectangle in pixels.
-     */
-  function updateRect (newX: number, newY: number, currentWidth: number, currentHeight: number): void {
-    d3.select('#selectRect')
-      .attr('x', newX)
-      .attr('y', newY)
-      .attr('width', currentWidth)
-      .attr('height', currentHeight);
+  const dragSelectAction = d3.drag()
+    .on('start', selStart)
+    .on('drag', selecting)
+    .on('end', selEnd);
+  canvas.call(dragSelectAction);
+  if (dragHandler) {
+    dragHandler.resetTo(dragSelectAction);
   }
 }

--- a/src/utils/SelectTools.ts
+++ b/src/utils/SelectTools.ts
@@ -65,6 +65,35 @@ export function unselect (): void {
 }
 
 /**
+ * Select a staff element.
+ * @param staff - The staff element in the DOM.
+ * @param dragHandler - The drag handler in use.
+ */
+export function selectStaff (staff: SVGGElement, dragHandler: DragHandler): void {
+  if (!staff.classList.contains('selected')) {
+    staff.classList.add('selected');
+    Color.unhighlight(staff);
+    Color.highlight(staff, '#d00');
+    SelectOptions.triggerSplitActions();
+    dragHandler.dragInit();
+  }
+}
+
+/**
+ * Select a layer element.
+ * @param layerElement - The layer element in the DOM.
+ * @param dragHandler - The drag handler in use.
+ */
+export function selectLayerElement (layerElement: SVGGElement, dragHandler: DragHandler): void {
+  if (!layerElement.classList.contains('selected')) {
+    layerElement.classList.add('selected');
+    Color.unhighlight(layerElement);
+    Color.highlight(layerElement, '#d00');
+    dragHandler.dragInit();
+  }
+}
+
+/**
  * Generic select function.
  * @param el - Element to select.
  * @param dragHandler - Only used for staves.
@@ -189,7 +218,7 @@ export function getStaffBBox (staff: SVGGElement): {ulx: number; uly: number; lr
       lrx = coordinates[2];
     }
   });
-  return { 'ulx': ulx, 'uly': uly, 'lrx': lrx, 'lry': lry, 'rotate': rotate };
+  return { ulx: ulx, uly: uly, lrx: lrx, lry: lry, rotate: rotate };
 }
 
 /**
@@ -238,35 +267,6 @@ export function selectNn (notNeumes: SVGGraphicsElement[]): boolean {
 }
 
 /**
- * Select a staff element.
- * @param staff - The staff element in the DOM.
- * @param dragHandler - The drag handler in use.
- */
-export function selectStaff (staff: SVGGElement, dragHandler: DragHandler): void {
-  if (!staff.classList.contains('selected')) {
-    staff.classList.add('selected');
-    Color.unhighlight(staff);
-    Color.highlight(staff, '#d00');
-    SelectOptions.triggerSplitActions();
-    dragHandler.dragInit();
-  }
-}
-
-/**
- * Select a layer element.
- * @param layerElement - The layer element in the DOM.
- * @param dragHandler - The drag handler in use.
- */
-export function selectLayerElement (layerElement: SVGGElement, dragHandler: DragHandler): void {
-  if (!layerElement.classList.contains('selected')) {
-    layerElement.classList.add('selected');
-    Color.unhighlight(layerElement);
-    Color.highlight(layerElement, '#d00');
-    dragHandler.dragInit();
-  }
-}
-
-/**
  * Handle selecting an array of elements based on the selection type.
  */
 export async function selectAll (elements: Array<SVGGraphicsElement>, neonView: NeonView, dragHandler: DragHandler): Promise<void> {
@@ -275,7 +275,6 @@ export async function selectAll (elements: Array<SVGGraphicsElement>, neonView: 
   if (elements.length === 0) {
     return;
   }
-
   let selectionClass;
   let containsClefOrCustosOrAccidOrDivLine = false;
   let containsNc = false;
@@ -480,7 +479,7 @@ export async function selectAll (elements: Array<SVGGraphicsElement>, neonView: 
                   .x.baseVal.value;
                 const orderSecondX = (groups[1].children[0] as SVGUseElement)
                   .x.baseVal.value;
-                let posFirstY, posSecondY;
+                let posFirstY: number, posSecondY: number;
 
                 if (orderFirstX < orderSecondX) {
                   posFirstY = (groups[0].children[0] as SVGUseElement)

--- a/src/workers/VerovioWorker.js
+++ b/src/workers/VerovioWorker.js
@@ -52,7 +52,7 @@ var Module = {
       font: 'Bravura',
       useFacsimile: true,
     });
-    console.debug("READY");
+    console.debug('READY');
     onmessage = handleNeonEvent;
     for (const message of backlog) {
       handleNeonEvent(message);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
         "target": "es2017",
         "sourceMap": true,
         "module": "commonjs",
-        "allowSyntheticDefaultImports": true
+        "allowSyntheticDefaultImports": true,
+        "resolveJsonModule": true
     },
     "include": [
         "./src/**/*.ts",


### PR DESCRIPTION
Fix files according to ESlint rules.

Changes to ESlint:
- Remove `no-use-before-define` rule.
- Add `object-curly-spacing` and `quote-props` so that our code looks prettier. 😃

Comments:
- A lot of typing needs to be fixed.
- ESlint still does not stop from long lines of code that go pass the standard 80 characters per line. Also, ESlint does not auto format such long lines. I'd suggest we use Prettier as an extension to ESlint. I've used Prettier extensively and it autoformats not just long lines of code but also long function signatures and long imports.