### PR TITLE
Add arrow key shortcuts.

### DIFF
--- a/src/Types.ts
+++ b/src/Types.ts
@@ -43,3 +43,9 @@ export type NeonManifest = {
   image: string;
   mei_annotations: WebAnnotation[];
 };
+
+/** An <svg> element from any DOM queries */
+export type HTMLSVGElement = HTMLElement & SVGSVGElement;
+
+/** "Selection By" type */
+export type SelectionType = 'selByStaff' | 'selByNeume' | 'selByNc' | 'selByLayerElement' | 'selBySyl' | 'selByBBox' | 'selByLayerElement';

--- a/src/utils/Select.ts
+++ b/src/utils/Select.ts
@@ -10,6 +10,7 @@ import { InfoInterface } from '../Interfaces';
 import ZoomHandler from '../SingleView/Zoom';
 
 import * as d3 from 'd3';
+import { HTMLSVGElement } from '../Types';
 
 let dragHandler: DragHandler, neonView: NeonView, info: InfoInterface, zoomHandler: ZoomHandler;
 let strokeWidth = 7;
@@ -41,6 +42,30 @@ function escapeKeyListener (evt: KeyboardEvent): void {
   }
 }
 
+function arrowKeyListener (evt: KeyboardEvent): void {
+  if (getSelectionType() !== 'selByBBox' || (evt.key !== 'ArrowLeft' && evt.key !== 'ArrowRight'))
+    return;
+
+  const selected = document.querySelector('.syllable-highlighted');
+  const syllables = Array.from(document.querySelectorAll('.syllable'));
+
+  // not all syllables have BBoxes; we must filter them out
+  const bboxSyllables = syllables.filter(syl => syl.querySelector('.sylTextRect-display') !== null);
+  const ind = bboxSyllables.indexOf(selected);
+
+  if (evt.key === 'ArrowLeft' && ind > 0) {
+    unselect();
+
+    const bbox = bboxSyllables[ind - 1].querySelector('.sylTextRect-display');
+    selectAll([bbox as SVGGraphicsElement], neonView, dragHandler);
+  } else if (evt.key === 'ArrowRight' && ind < bboxSyllables.length - 1) {
+    unselect();
+
+    const bbox = bboxSyllables[ind + 1].querySelector('.sylTextRect-display');
+    selectAll([bbox as SVGGraphicsElement], neonView, dragHandler);
+  }
+}
+
 function isSelByBBox (): boolean {
   const selByBBox = document.getElementById('selByBBox');
   if (selByBBox) {
@@ -49,7 +74,7 @@ function isSelByBBox (): boolean {
   return false;
 }
 
-function stopPropHandler (evt): void { evt.stopPropagation(); }
+function stopPropHandler (evt: Event): void { evt.stopPropagation(); }
 
 /**
  * Apply listeners for click selection.
@@ -64,6 +89,9 @@ export function clickSelect (selector: string): void {
   // Click away listeners
   document.body.removeEventListener('keydown', escapeKeyListener);
   document.body.addEventListener('keydown', escapeKeyListener);
+
+  document.body.removeEventListener('keydown', arrowKeyListener);
+  document.body.addEventListener('keydown', arrowKeyListener);
 
   document.getElementById('container')
     .addEventListener('contextmenu', (evt) => { evt.preventDefault(); });

--- a/src/utils/SelectTools.ts
+++ b/src/utils/SelectTools.ts
@@ -2,7 +2,7 @@ import * as Color from './Color';
 import { updateHighlight } from '../DisplayPanel/DisplayControls';
 import * as Grouping from '../SquareEdit/Grouping';
 import { resize } from './Resize';
-import { Attributes } from '../Types';
+import { Attributes, SelectionType } from '../Types';
 import NeonView from '../NeonView';
 import DragHandler from './DragHandler';
 import * as SelectOptions from '../SquareEdit/SelectOptions';
@@ -11,10 +11,10 @@ import * as d3 from 'd3';
 /**
  * @returns The selection mode chosen by the user.
  */
-export function getSelectionType (): string {
+export function getSelectionType (): SelectionType {
   const element = document.getElementsByClassName('sel-by is-active');
   if (element.length !== 0) {
-    return element[0].id;
+    return element[0].id as SelectionType;
   } else {
     return null;
   }


### PR DESCRIPTION
## New Shortcut: Move between bounding boxes by arrow keys
Adds feature requested by @carrieeex in issue #665 to use arrow keys for moving between bounding boxes.

> It would be nice if we can use arrow keys (left and right) to switch between different bounding boxes. For example, when users choose "select by BBox", and then click one of the bounding boxes, press the right arrow key would switch to the BBox on the right.

Demo:

https://user-images.githubusercontent.com/40512164/167648259-9f4c0e5c-f1fe-4d19-9104-40f55601e24b.mov

EDIT:

Arrow keys now move correctly through syllables.

https://user-images.githubusercontent.com/40512164/167668314-40c98e51-917e-4510-a7ad-e85330b46b73.mov
