### PR TITLE
Selected Divline Fix

### DIFF
--- a/src/utils/Color.ts
+++ b/src/utils/Color.ts
@@ -45,7 +45,7 @@ export function unhighlight(staff?: SVGGElement): void {
           rect.closest('.syl').classList.contains('selected')
           // rect.closest('.layer').classList.contains('selected')
         ){
-          rect.style.fill = 'red';
+          rect.style.fill = '#d00';
         } else {
           rect.style.fill = 'blue';
         }
@@ -71,7 +71,7 @@ export function unsetGroupingHighlight(): void {
   const highlighted = Array.from(document.getElementsByClassName('highlighted'))
     .filter((elem: HTMLElement) => !elem.parentElement.classList.contains('selected'));
   highlighted.forEach((elem: HTMLElement) => {
-    elem.setAttribute('fill', null);
+    elem.setAttribute('#d00', null);
     let rects = elem.querySelectorAll('.sylTextRect-display');
     if (!rects.length) {
       if (elem.closest('.syllable') !== null) {
@@ -82,7 +82,7 @@ export function unsetGroupingHighlight(): void {
       if (rect.closest('.syllable').classList.contains('selected') || 
       rect.closest('.syl').classList.contains('selected')
       ){
-        rect.style.fill = 'red';
+        rect.style.fill = '#d00';
       } else {
         rect.style.fill = 'blue';
       }

--- a/src/utils/SelectTools.ts
+++ b/src/utils/SelectTools.ts
@@ -36,11 +36,18 @@ export function unselect (): void {
       selected.style.fill = '';
     }
   });
+
+  // Set the strokes of all divlines back to black
+  Array.from(document.getElementsByClassName('divLine')).forEach((syllable: HTMLElement) => {
+    syllable.style.stroke = 'black';
+  });
+
   Array.from(document.getElementsByClassName('text-select')).forEach((el: SVGElement) => {
     el.style.color = '';
     el.style.fontWeight = '';
     el.classList.remove('text-select');
   });
+
   Array.from(document.getElementsByClassName('sylTextRect-display')).forEach((sylRect: HTMLElement) => {
     sylRect.style.fill = 'blue';
   });
@@ -106,15 +113,28 @@ export function select (el: SVGGraphicsElement, dragHandler?: DragHandler): void
   if (el.classList.contains('layer')) {
     return selectLayerElement(el, dragHandler);
   }
+
   if (!el.classList.contains('selected') && !el.classList.contains('sylTextRect') &&
       !el.classList.contains('sylTextRect-display')) {
     el.classList.add('selected');
+    // set fill to red
+    // set stroke to red only if selected elem is a divLine
     el.style.fill = '#d00';
+    el.style.stroke = (el.classList.contains('divLine'))? 'red' : 'black';
+
     if (el.querySelectorAll('.sylTextRect-display').length) {
       el.querySelectorAll('.sylTextRect-display').forEach((elem: HTMLElement) => {
         elem.style.fill = 'red';
       });
     }
+
+    if (el.querySelectorAll('.divLine').length) {
+      el.querySelectorAll('.divLine').forEach((elem: HTMLElement) => {
+        elem.style.stroke = 'red';
+      });
+    }
+
+    // Set color of the corresponding text in the text panel to red
     let sylId;
     if (el.classList.contains('syllable')) {
       sylId = el.id;
@@ -333,7 +353,7 @@ export async function selectAll (elements: Array<SVGGraphicsElement>, neonView: 
     }
   }
   // Select the elements
-  groupsToSelect.forEach((group: SVGGraphicsElement) => { select(group, dragHandler); });
+  groupsToSelect.forEach((group: SVGGraphicsElement) => { select(group, dragHandler) });
 
   /* Determine the context menu to display (if any) */
 

--- a/src/utils/SelectTools.ts
+++ b/src/utils/SelectTools.ts
@@ -124,13 +124,13 @@ export function select (el: SVGGraphicsElement, dragHandler?: DragHandler): void
 
     if (el.querySelectorAll('.sylTextRect-display').length) {
       el.querySelectorAll('.sylTextRect-display').forEach((elem: HTMLElement) => {
-        elem.style.fill = 'red';
+        elem.style.fill = '#d00';
       });
     }
 
     if (el.querySelectorAll('.divLine').length) {
       el.querySelectorAll('.divLine').forEach((elem: HTMLElement) => {
-        elem.style.stroke = 'red';
+        elem.style.stroke = '#d00';
       });
     }
 

--- a/src/utils/SelectTools.ts
+++ b/src/utils/SelectTools.ts
@@ -120,7 +120,7 @@ export function select (el: SVGGraphicsElement, dragHandler?: DragHandler): void
     // set fill to red
     // set stroke to red only if selected elem is a divLine
     el.style.fill = '#d00';
-    el.style.stroke = (el.classList.contains('divLine'))? 'red' : 'black';
+    el.style.stroke = (el.classList.contains('divLine'))? '#d00' : 'black';
 
     if (el.querySelectorAll('.sylTextRect-display').length) {
       el.querySelectorAll('.sylTextRect-display').forEach((elem: HTMLElement) => {
@@ -254,7 +254,7 @@ export function selectBBox (el: SVGGraphicsElement, dragHandler: DragHandler, ne
     syl.classList.add('selected');
     bbox.style.fill = '#d00';
     const closest = el.closest('.syllable') as HTMLElement;
-    closest.style.fill = 'red';
+    closest.style.fill = '#d00';
     closest.classList.add('syllable-highlighted');
     if (neonView !== undefined ){
       resize(syl as SVGGraphicsElement, neonView, dragHandler);


### PR DESCRIPTION
Divlines now appear red when selected by user. Previously, there was no visual indication that a divline had been selected, which led to occasional confusion (especially in cases when divlines were selected by mistake).