### PR TITLE
Empty Neume/Syllable removal now immediately updates the page.

### DIFF
--- a/src/utils/EditControls.ts
+++ b/src/utils/EditControls.ts
@@ -54,26 +54,48 @@ export function initNavbar (neonView: NeonView): void {
       const parser = new DOMParser();
       const meiDoc = parser.parseFromString(meiString, 'text/xml');
       const mei = meiDoc.documentElement;
-      
-      // Check for syllables without neumes
       const syllables = Array.from(mei.getElementsByTagName('syllable'));
+
+      // Check for syllables without neumes
       let hasEmptySyllables = false;
+      let removeSyllableActions = [];
       for (const syllable of syllables) {
+        // if empty syllable found, create action object for removing empty neume
         if (syllable.getElementsByTagName('neume').length === 0) {
-          syllable.remove();
+          let action = {
+            action: 'remove',
+            param: {
+              elementId: syllable.getAttribute('xml:id')
+            }
+          }
+          // add action object to array (chain) of action objects
+          removeSyllableActions.push(action);
           hasEmptySyllables = true;
         }
       }
 
+      // check if empty syllables were found
       if (!hasEmptySyllables) {
-        Notification.queueNotification('No empty syllables found.');
-      } else {
-        // update cached MEI file
-        const serializer = new XMLSerializer();
-        const updatedMeiString = vkbeautify.xml(serializer.serializeToString(meiDoc));
-        neonView.core.loadData(uri, updatedMeiString);
+        Notification.queueNotification('No empty syllables found');
+      }
+      else {
+        // create "chain action" object
+        let chainRemoveAction = {
+          "action": "chain",
+          "param": removeSyllableActions
+        };
 
-        Notification.queueNotification('Removed empty Syllables.');
+        // execute action that removes all empty syllables
+        // "result" value is true or false (true if chain of actions was successful)
+        neonView.edit(chainRemoveAction, uri).then((result) => {
+          if (result) {
+            neonView.updateForCurrentPage();
+            Notification.queueNotification('Removed empty Syllables');
+          }
+          else {
+            Notification.queueNotification('Failed to remove empty Syllables');
+          }
+        });
       }
     });
   });
@@ -86,26 +108,48 @@ export function initNavbar (neonView: NeonView): void {
       const parser = new DOMParser();
       const meiDoc = parser.parseFromString(meiString, 'text/xml');
       const mei = meiDoc.documentElement;
+      const neumes = Array.from(mei.getElementsByTagName('neume'));
 
       // Check for neumes without neume components
-      const neumes = Array.from(mei.getElementsByTagName('neume'));
-      let hasEmptyNeume = false;
+      let hasEmptyNeumes = false;
+      let removeNeumesActions = [];
       for (const neume of neumes) {
-        if (neume.getElementsByTagName('nc').length === 0) {
-          neume.remove();
-          hasEmptyNeume = true;
+        // if empty syllable found, create action object for removing empty neume
+        if (neume.getElementsByTagName('neume').length === 0) {
+          let action = {
+            action: 'remove',
+            param: {
+              elementId: neume.getAttribute('xml:id')
+            }
+          }
+          // add action object to array (chain) of action objects
+          removeNeumesActions.push(action);
+          hasEmptyNeumes = true;
         }
       }
 
-      if (!hasEmptyNeume) {
-        Notification.queueNotification('No empty neumes found.');
-      } else {
-        // update cached MEI file
-        const serializer = new XMLSerializer();
-        const updatedMeiString = vkbeautify.xml(serializer.serializeToString(meiDoc));
-        neonView.core.loadData(uri, updatedMeiString);
+      // check if empty neumes were found
+      if (!hasEmptyNeumes) {
+        Notification.queueNotification('No empty Neumes found');
+      }
+      else {
+        // create "chain action" object
+        let chainRemoveAction = {
+          "action": "chain",
+          "param": removeNeumesActions,
+        };
 
-        Notification.queueNotification('Removed empty neumes.');
+        // execute action that removes all empty neumes
+        // "result" value is true or false (true if chain of actions was successful)
+        neonView.edit(chainRemoveAction, uri).then((result) => {
+          if (result) {
+            neonView.updateForCurrentPage();
+            Notification.queueNotification('Removed empty Neumes');
+          }
+          else {
+            Notification.queueNotification('Failed to remove empty Neumes');
+          }
+        });
       }
     });
   });

--- a/src/utils/EditControls.ts
+++ b/src/utils/EditControls.ts
@@ -112,7 +112,7 @@ export function initNavbar (neonView: NeonView): void {
 
       // Check for neumes without neume components
       let hasEmptyNeumes = false;
-      let removeNeumesActions = [];
+      let removeNeumeActions = [];
       for (const neume of neumes) {
         // if empty neume found, create action object for removing it
         if (neume.getElementsByTagName('nc').length === 0) {
@@ -123,7 +123,7 @@ export function initNavbar (neonView: NeonView): void {
             }
           }
           // add action object to array (chain) of action objects
-          removeNeumesActions.push(action);
+          removeNeumeActions.push(action);
           hasEmptyNeumes = true;
         }
       }
@@ -136,7 +136,7 @@ export function initNavbar (neonView: NeonView): void {
         // create "chain action" object
         let chainRemoveAction = {
           "action": "chain",
-          "param": removeNeumesActions,
+          "param": removeNeumeActions,
         };
 
         // execute action that removes all empty neumes

--- a/src/utils/EditControls.ts
+++ b/src/utils/EditControls.ts
@@ -60,7 +60,7 @@ export function initNavbar (neonView: NeonView): void {
       let hasEmptySyllables = false;
       let removeSyllableActions = [];
       for (const syllable of syllables) {
-        // if empty syllable found, create action object for removing empty neume
+        // if empty syllable found, create action object for removing it
         if (syllable.getElementsByTagName('neume').length === 0) {
           let action = {
             action: 'remove',
@@ -114,8 +114,8 @@ export function initNavbar (neonView: NeonView): void {
       let hasEmptyNeumes = false;
       let removeNeumesActions = [];
       for (const neume of neumes) {
-        // if empty syllable found, create action object for removing empty neume
-        if (neume.getElementsByTagName('neume').length === 0) {
+        // if empty neume found, create action object for removing it
+        if (neume.getElementsByTagName('nc').length === 0) {
           let action = {
             action: 'remove',
             param: {

--- a/src/utils/EditControls.ts
+++ b/src/utils/EditControls.ts
@@ -2,7 +2,6 @@ import * as Notification from './Notification';
 import NeonView from '../NeonView';
 import { navbarDropdownFileMenu, navbarDropdownMEIActionsMenu, undoRedoPanel } from './EditContents';
 import { convertStaffToSb } from './ConvertMei';
-import * as vkbeautify from 'vkbeautify';
 
 /**
  * Set listener on switching EditMode button to File dropdown in the navbar.
@@ -62,14 +61,14 @@ export function initNavbar (neonView: NeonView): void {
       for (const syllable of syllables) {
         // if empty syllable found, create action object for removing it
         if (syllable.getElementsByTagName('neume').length === 0) {
-          let action = {
+          let toRemove = {
             action: 'remove',
             param: {
               elementId: syllable.getAttribute('xml:id')
             }
-          }
+          };
           // add action object to array (chain) of action objects
-          removeSyllableActions.push(action);
+          removeSyllableActions.push(toRemove);
           hasEmptySyllables = true;
         }
       }
@@ -80,9 +79,9 @@ export function initNavbar (neonView: NeonView): void {
       }
       else {
         // create "chain action" object
-        let chainRemoveAction = {
-          "action": "chain",
-          "param": removeSyllableActions
+        const chainRemoveAction = {
+          action: 'chain',
+          param: removeSyllableActions
         };
 
         // execute action that removes all empty syllables
@@ -116,14 +115,14 @@ export function initNavbar (neonView: NeonView): void {
       for (const neume of neumes) {
         // if empty neume found, create action object for removing it
         if (neume.getElementsByTagName('nc').length === 0) {
-          let action = {
+          let toRemove = {
             action: 'remove',
             param: {
               elementId: neume.getAttribute('xml:id')
             }
-          }
+          };
           // add action object to array (chain) of action objects
-          removeNeumeActions.push(action);
+          removeNeumeActions.push(toRemove);
           hasEmptyNeumes = true;
         }
       }
@@ -134,9 +133,9 @@ export function initNavbar (neonView: NeonView): void {
       }
       else {
         // create "chain action" object
-        let chainRemoveAction = {
-          "action": "chain",
-          "param": removeNeumeActions,
+        const chainRemoveAction = {
+          action: 'chain',
+          param: removeNeumeActions,
         };
 
         // execute action that removes all empty neumes


### PR DESCRIPTION
Fixes #820 

Changed neume.remove() and syllable.remove() to actual neonView edit actions. This change allows the svg on the page to be updated immediately after the action occurs. Additionally, it is now possible to undo and redo the action of removing empty neumes and syllables.