### PR TITLE
🐛 Fix reset zoom button.

### DIFF
--- a/src/SingleView/Zoom.ts
+++ b/src/SingleView/Zoom.ts
@@ -81,6 +81,7 @@ export class ZoomHandler {
   resetZoomAndPan (): void {
     const bgimg = document.getElementById('bgimg') as HTMLImageElement;
     this.viewBox = new ViewBox(parseInt(bgimg.getAttribute('width')), parseInt(bgimg.getAttribute('height')));
+    this.updateSVGViewBox();
   }
 
   /**


### PR DESCRIPTION
Fixes #683 .

Undo accidental change in resetZoomAndPan() function in `Zoom.ts`. I looked at `git log -p -- src/SingleView/Zoom.ts` and this seems to be the culprit. Everything else works as before.

https://user-images.githubusercontent.com/40512164/170086205-36b88049-0853-4ce5-bad4-e7ed48f58a2d.mov
