### PR TITLE
fix zoom shortcuts and up/down arrow reactivity🐛

### DIFF
--- a/src/DisplayPanel/DisplayControls.ts
+++ b/src/DisplayPanel/DisplayControls.ts
@@ -31,18 +31,21 @@ export function setZoomControls (zoomHandler?: ZoomHandler): void {
 
   // zoomSlider.addEventListener('input', inputChangeHandler);
   zoomSlider.addEventListener('mouseup', inputChangeHandler);
+  zoomSlider.disabled = false;
 
   document.body.addEventListener('keydown', (evt) => {
     const currentZoom = parseInt(zoomOutput.value);
-    if (evt.key === '+') { // increase zoom by 20
+    if (evt.key === 'ArrowUp' || evt.key === 'ArrowDown') {
+      evt.preventDefault();
+    } else if (evt.key === '+') { // increase zoom by 20
       const newZoom = Math.min(currentZoom + 20, parseInt(zoomSlider.getAttribute('max')));
       zoomHandler.zoomTo(newZoom / 100.0);
       zoomOutput.value = String(newZoom);
       zoomSlider.value = String(newZoom);
-    } else if (evt.key === '-') { // decrease zoom by 20
+    } else if (evt.key === '_') { // decrease zoom by 20
       const newZoom = Math.max(currentZoom - 20, parseInt(zoomSlider.getAttribute('min')));
       zoomHandler.zoomTo(newZoom / 100.0);
-      zoomOutput.value = String(Math.round(newZoom));
+      zoomOutput.value = String(newZoom);
       zoomSlider.value = String(newZoom);
     } else if (evt.key === '0') {
       zoomOutput.value = '100';
@@ -50,8 +53,6 @@ export function setZoomControls (zoomHandler?: ZoomHandler): void {
       zoomHandler.resetZoomAndPan();
     }
   });
-
-  zoomSlider.disabled = false;
 }
 
 /**

--- a/src/DisplayPanel/DisplayControls.ts
+++ b/src/DisplayPanel/DisplayControls.ts
@@ -35,7 +35,8 @@ export function setZoomControls (zoomHandler?: ZoomHandler): void {
 
   document.body.addEventListener('keydown', (evt) => {
     const currentZoom = parseInt(zoomOutput.value);
-    if (evt.key === 'ArrowUp' || evt.key === 'ArrowDown') {
+    if (evt.key === 'ArrowUp' || evt.key === 'ArrowDown' || 
+    evt.key === 'ArrowRight' || evt.key === 'ArrowLeft') {
       evt.preventDefault();
     } else if (evt.key === '+') { // increase zoom by 20
       const newZoom = Math.min(currentZoom + 20, parseInt(zoomSlider.getAttribute('max')));

--- a/src/SquareEdit/Contents.ts
+++ b/src/SquareEdit/Contents.ts
@@ -314,19 +314,21 @@ export const hotkeysModal =
                     <div>+</div>
                     <div class="hotkey-entry">+</div>
                 </div>
-                <div class="hotkey-entry-description">Zoom in</div>        
+                <div class="hotkey-entry-description">Zoom In</div>        
             </div>
             <div class="hotkey-entry-container">
             <div class="hotkey-container">
+                <div class="hotkey-entry">Shift</div>
+                <div>+</div>
                 <div class="hotkey-entry">-</div>
             </div>
-            <div class="hotkey-entry-description">Zoom out</div>
+            <div class="hotkey-entry-description">Zoom Out</div>
             </div>
             <div class="hotkey-entry-container">
             <div class="hotkey-container">
                 <div class="hotkey-entry">0</div>
             </div>
-            <div class="hotkey-entry-description">Zoom reset</div>
+            <div class="hotkey-entry-description">Zoom Reset</div>
             </div>
             <div class="hotkey-entry-container">
             <div class="hotkey-container">


### PR DESCRIPTION
deactivates default action on up and down arrow for slider, change shortcuts to _ and +.
Fixes #850 