### PR TITLE
♻️🐛 Replace try/catch for explicit null checks.

### DIFF
--- a/src/SquareEdit/Contents.ts
+++ b/src/SquareEdit/Contents.ts
@@ -262,9 +262,9 @@ export const layerElementOutActionContents =
  */
 export const layerElementInActionContents =
     `<div class="right-side-panel-btns-container">
-        <button class="button" id="delete">Delete</button>
-        <button class="button" id="moveOuttaSyllable">Move out of syllable</button>
-        <button class="button" id="changeStaff">Re-associate to nearest staff</button>
+        <button class="side-panel-btn" id="delete">Delete</button>
+        <button class="side-panel-btn" id="moveOuttaSyllable">Move out of syllable</button>
+        <button class="side-panel-btn" id="changeStaff">Re-associate to nearest staff</button>
     </div>`;
 
 /**

--- a/src/SquareEdit/SelectOptions.ts
+++ b/src/SquareEdit/SelectOptions.ts
@@ -251,21 +251,54 @@ export function moveOuttaSyllableHandler(): void {
 //   } catch (e) {}
 // }
 
+function addDeleteListener(): void {
+  const del = document.getElementById('delete');
+
+  if (del) {
+    del.removeEventListener('click', removeHandler);
+    del.addEventListener('click', removeHandler);
+
+    // TODO: should this be outside the if condition?
+    document.body.addEventListener('keydown', deleteButtonHandler);
+  }
+}
+
+export function addChangeStaffListener(): void {
+  const staff = document.getElementById('changeStaff');
+  staff?.removeEventListener('click', changeStaffHandler);
+  staff?.addEventListener('click', changeStaffHandler);
+}
+
+/**
+ * Function to set the HTML content of edit controls: either #moreEdit or #extraEdit
+ *
+ * @param {'moreEdit' | 'extraEdit'} editType - The type of edit controls
+ * @param {string} contents - The innerHTML contents
+ * @param {boolean} replace - Is the innerHTML being replaced, or being added to?
+ */
+function setEditControls(editType: 'moreEdit' | 'extraEdit', contents: string, replace = true): void {
+  const edit = document.getElementById(editType);
+  
+  if (edit) {
+    edit.parentElement.classList.remove('hidden');
+
+    if (replace)
+      edit.innerHTML = contents;
+    else
+      edit.innerHTML += contents;
+  }
+}
+
 /**
  * Trigger the extra nc action menu for a selection.
  */
 export function triggerNcActions (nc: SVGGraphicsElement): void {
   endOptionsSelection();
-  try {
-    const moreEdit = document.getElementById('moreEdit');
-    moreEdit.parentElement.classList.remove('hidden');
-    moreEdit.innerHTML = Contents.defaultActionContents;
-  } catch (e) {}
-  try {
-    const extraEdit = document.getElementById('extraEdit');
-    extraEdit.parentElement.classList.remove('hidden');
-    extraEdit.innerHTML = Contents.ncActionContents;
-  } catch (e) {}
+
+  setEditControls('moreEdit', Contents.defaultActionContents);
+  setEditControls('extraEdit', Contents.ncActionContents);
+  addDeleteListener();
+
   document.querySelector('#Punctum.dropdown-item')
     .addEventListener('click', () => {
       const unsetInclinatum = unsetInclinatumAction(nc.id);
@@ -409,13 +442,6 @@ export function triggerNcActions (nc: SVGGraphicsElement): void {
       });
     });  
 
-  try {
-    const del = document.getElementById('delete');
-    del.removeEventListener('click', removeHandler);
-    del.addEventListener('click', removeHandler);
-  } catch (e) {}
-  document.body.addEventListener('keydown', deleteButtonHandler);
-
   initOptionsListeners();
 }
 
@@ -424,16 +450,11 @@ export function triggerNcActions (nc: SVGGraphicsElement): void {
  */
 export function triggerNeumeActions (): void {
   endOptionsSelection();
-  try {
-    const moreEdit = document.getElementById('moreEdit');
-    moreEdit.parentElement.classList.remove('hidden');
-    moreEdit.innerHTML = Contents.defaultNeumeActionContents;
-  } catch (e) {}
-  try {
-    const extraEdit = document.getElementById('extraEdit');
-    extraEdit.parentElement.classList.remove('hidden');
-    extraEdit.innerHTML = Contents.neumeActionContents;
-  } catch (e) {}
+
+  setEditControls('moreEdit', Contents.defaultNeumeActionContents);
+  setEditControls('extraEdit', Contents.neumeActionContents);
+  addDeleteListener();
+
   const neume = document.querySelectorAll('.selected');
   if (neume.length !== 1) {
     console.warn('More than one neume selected! Cannot trigger Neume ClickSelect actions.');
@@ -543,12 +564,6 @@ export function triggerNeumeActions (): void {
       neonView.updateForCurrentPage();
     });
   }
-  try {
-    const del = document.getElementById('delete');
-    del.removeEventListener('click', removeHandler);
-    del.addEventListener('click', removeHandler);
-  } catch (e) {}
-  document.body.addEventListener('keydown', deleteButtonHandler);
 
   initOptionsListeners();
 }
@@ -558,24 +573,18 @@ export function triggerNeumeActions (): void {
  */
 export function triggerSyllableActions (): void {
   endOptionsSelection();
-  try {
-    const moreEdit = document.getElementById('moreEdit');
-    moreEdit.parentElement.classList.remove('hidden');
-    moreEdit.innerHTML =
-    `<div class="right-side-panel-btns-container">
-        <button class="side-panel-btn" id="mergeSyls">Merge Syllables</button>
-        <button class="side-panel-btn" id="ungroupNeumes">Ungroup</button>
-        <button class="side-panel-btn" id="delete">Delete</button>
-        <button class="side-panel-btn" id="changeStaff">Re-associate to nearest staff</button>
-      </div>`;
-    document.getElementById('changeStaff').addEventListener('click', changeStaffHandler);
-  } catch (e) { console.debug(e); }
-  try {
-    const del = document.getElementById('delete');
-    del.removeEventListener('click', removeHandler);
-    del.addEventListener('click', removeHandler);
-  } catch (e) {}
-  document.body.addEventListener('keydown', deleteButtonHandler);
+
+  const extraActionsHTML = `
+    <div class="right-side-panel-btns-container">
+      <button class="side-panel-btn" id="mergeSyls">Merge Syllables</button>
+      <button class="side-panel-btn" id="ungroupNeumes">Ungroup</button>
+      <button class="side-panel-btn" id="delete">Delete</button>
+      <button class="side-panel-btn" id="changeStaff">Re-associate to nearest staff</button>
+    </div>
+  `;
+  setEditControls('moreEdit', extraActionsHTML);
+  addChangeStaffListener();
+  addDeleteListener();
 }
 
 /**
@@ -584,23 +593,12 @@ export function triggerSyllableActions (): void {
  */
 export function triggerClefActions (clef: SVGGraphicsElement): void {
   endOptionsSelection();
-  try {
-    const moreEdit = document.getElementById('moreEdit');
-    moreEdit.parentElement.classList.remove('hidden');
-    // custos contents is just the delete button
-    moreEdit.innerHTML = Contents.custosActionContents;
-  } catch (e) {}
-  try {
-    const extraEdit = document.getElementById('extraEdit');
-    extraEdit.parentElement.classList.remove('hidden');
-    extraEdit.innerHTML = Contents.clefActionContents;
-  } catch (e) {}
 
-  try {
-    document.getElementById('changeStaff')
-      .addEventListener('click', changeStaffHandler);
-  } catch (e) {console.debug(e);}
-  
+  setEditControls('moreEdit', Contents.custosActionContents);
+  setEditControls('extraEdit', Contents.clefActionContents);
+  addChangeStaffListener();
+  addDeleteListener();
+
   document.querySelector('#CClef.dropdown-item')
     .addEventListener('click', () => {
       const setCClef: SetClefAction = {
@@ -640,15 +638,6 @@ export function triggerClefActions (clef: SVGGraphicsElement): void {
       });
     });
 
-  try {
-    const del = document.getElementById('delete');
-    del.removeEventListener('click', removeHandler);
-    del.addEventListener('click', removeHandler);
-    document.getElementById('changeStaff').addEventListener('click', changeStaffHandler);
-  } catch (e) {console.debug(e);}
-  document.body.addEventListener('keydown', deleteButtonHandler);
-
-
   initOptionsListeners();
 }
 
@@ -657,23 +646,9 @@ export function triggerClefActions (clef: SVGGraphicsElement): void {
  */
 export function triggerCustosActions (): void {
   endOptionsSelection();
-  try {
-    const moreEdit = document.getElementById('moreEdit');
-    moreEdit.parentElement.classList.remove('hidden');
-    moreEdit.innerHTML += Contents.custosActionContents;
-  } catch (e) {}
-
-  try {
-    document.getElementById('changeStaff')
-      .addEventListener('click', changeStaffHandler);
-  } catch (e) {console.debug(e);}
-
-  try {
-    const del = document.getElementById('delete');
-    del.removeEventListener('click', removeHandler);
-    del.addEventListener('click', removeHandler);
-    document.body.addEventListener('keydown', deleteButtonHandler);
-  } catch (e) {}
+  setEditControls('moreEdit', Contents.custosActionContents);
+  addChangeStaffListener();
+  addDeleteListener();
 }
 
 /**
@@ -681,37 +656,18 @@ export function triggerCustosActions (): void {
  */
 export function triggerAccidActions (accid: SVGGraphicsElement): void {
   endOptionsSelection();
-  try {
-    const moreEdit = document.getElementById('moreEdit');
-    moreEdit.parentElement.classList.remove('hidden');
-    if (accid.parentElement.classList.contains('syllable')) {
-      moreEdit.innerHTML += Contents.layerElementInActionContents;
-    }
-    else {
-      moreEdit.innerHTML += Contents.layerElementOutActionContents;
-    }
-  } catch (e) {}
 
-  try {
-    const extraEdit = document.getElementById('extraEdit');
-    extraEdit.parentElement.classList.remove('hidden');
-    extraEdit.innerHTML = Contents.accidActionContents;
-  } catch (e) {}
+  const isSyllableInAccid = accid.parentElement.classList.contains('syllable');
+  const moreEditContents = (isSyllableInAccid)
+    ? Contents.layerElementInActionContents
+    : Contents.layerElementOutActionContents;
+  setEditControls('moreEdit', moreEditContents, false);
+  setEditControls('extraEdit', Contents.accidActionContents);
+  addDeleteListener();
 
-  try {
-    document.getElementById('changeStaff')
-      .addEventListener('click', changeStaffHandler);
-  } catch (e) {console.debug(e);}
-
-  try {
-    document.getElementById('insertToSyllable')
-      .addEventListener('click', insertToSyllableHandler);
-  } catch (e) {console.debug(e);}
-
-  try {
-    document.getElementById('moveOuttaSyllable')
-      .addEventListener('click', moveOuttaSyllableHandler);
-  } catch (e) {console.debug(e);}
+  addChangeStaffListener();
+  document.getElementById('insertToSyllable')?.addEventListener('click', insertToSyllableHandler);
+  document.getElementById('moveOuttaSyllable')?.addEventListener('click', moveOuttaSyllableHandler);
 
   document.querySelector('#ChangeToFlat.dropdown-item')
     .addEventListener('click', () => {
@@ -754,13 +710,6 @@ export function triggerAccidActions (accid: SVGGraphicsElement): void {
       });
     });
 
-  try {
-    const del = document.getElementById('delete');
-    del.removeEventListener('click', removeHandler);
-    del.addEventListener('click', removeHandler);
-    document.body.addEventListener('keydown', deleteButtonHandler);
-  } catch (e) {}
-
   initOptionsListeners();
 }
 
@@ -769,38 +718,17 @@ export function triggerAccidActions (accid: SVGGraphicsElement): void {
  */
 export function triggerLayerElementActions (element: SVGGraphicsElement): void {
   endOptionsSelection();
-  try {
-    const moreEdit = document.getElementById('moreEdit');
-    moreEdit.parentElement.classList.remove('hidden');
-    if (element.parentElement.classList.contains('syllable')) {
-      moreEdit.innerHTML += Contents.layerElementInActionContents;
-    }
-    else {
-      moreEdit.innerHTML += Contents.layerElementOutActionContents;
-    }
-  } catch (e) {}
 
-  try {
-    document.getElementById('changeStaff')
-      .addEventListener('click', changeStaffHandler);
-  } catch (e) {console.debug(e);}
+  const parentIsSyllable = element.parentElement.classList.contains('syllable');
+  const layerElementActions = parentIsSyllable
+    ? Contents.layerElementInActionContents
+    : Contents.layerElementOutActionContents;
+  setEditControls('moreEdit', layerElementActions, false);
+  addDeleteListener();
 
-  try {
-    const del = document.getElementById('delete');
-    del.removeEventListener('click', removeHandler);
-    del.addEventListener('click', removeHandler);
-    document.body.addEventListener('keydown', deleteButtonHandler);
-  } catch (e) {}
-
-  try {
-    document.getElementById('insertToSyllable')
-      .addEventListener('click', insertToSyllableHandler);
-  } catch (e) {console.debug(e);}
-
-  try {
-    document.getElementById('moveOuttaSyllable')
-      .addEventListener('click', moveOuttaSyllableHandler);
-  } catch (e) {console.debug(e);}
+  addChangeStaffListener();
+  document.getElementById('insertToSyllable')?.addEventListener('click', insertToSyllableHandler);
+  document.getElementById('moveOuttaSyllable')?.addEventListener('click', moveOuttaSyllableHandler);
 }
 
 
@@ -809,23 +737,12 @@ export function triggerLayerElementActions (element: SVGGraphicsElement): void {
  */
 export function triggerStaffActions (): void {
   endOptionsSelection();
-  try {
-    const moreEdit = document.getElementById('moreEdit');
-    moreEdit.parentElement.classList.remove('hidden');
-    moreEdit.innerHTML = Contents.staffActionContents;
-  } catch (e) {}
+  setEditControls('moreEdit', Contents.staffActionContents);
+  addDeleteListener();
 
-  document.getElementById('merge-systems')
-    .addEventListener('click', () => {
-      Grouping.mergeStaves();
-    });
-
-  try {
-    const del = document.getElementById('delete');
-    del.removeEventListener('click', removeHandler);
-    del.addEventListener('click', removeHandler);
-  } catch (e) {}
-  document.body.addEventListener('keydown', deleteButtonHandler);
+  document.getElementById('merge-systems').addEventListener('click', () => {
+    Grouping.mergeStaves();
+  });
 }
 
 /**
@@ -848,11 +765,8 @@ export function triggerStaffSplitMode (): void {
  */
 export function triggerSplitActions (): void {
   endOptionsSelection();
-  try {
-    const moreEdit = document.getElementById('moreEdit');
-    moreEdit.parentElement.classList.remove('hidden');
-    moreEdit.innerHTML = Contents.splitActionContents;
-  } catch (e) {}
+  setEditControls('moreEdit', Contents.splitActionContents);
+  addDeleteListener();
 
   // TODO add trigger for split action
   document.getElementById('split-system')
@@ -892,13 +806,6 @@ export function triggerSplitActions (): void {
         endOptionsSelection();
       }
     });
-
-  try {
-    const del = document.getElementById('delete');
-    del.removeEventListener('click', removeHandler);
-    del.addEventListener('click', removeHandler);
-  } catch (e) {}
-  document.body.addEventListener('keydown', deleteButtonHandler);
 }
 
 /**
@@ -906,23 +813,9 @@ export function triggerSplitActions (): void {
  */
 export function triggerDefaultSylActions (): void {
   endOptionsSelection();
-  try {
-    const moreEdit = document.getElementById('moreEdit');
-    moreEdit.parentElement.classList.remove('hidden');
-    moreEdit.innerHTML = Contents.defaultSylActionContents;
-  } catch (e) {}
-
-  try {
-    const del = document.getElementById('delete');
-    del.removeEventListener('click', removeHandler);
-    del.addEventListener('click', removeHandler);
-  } catch (e) {}
-  document.body.addEventListener('keydown', deleteButtonHandler);
-  try {
-    const changeStaff = document.getElementById('changeStaff');
-    changeStaff.removeEventListener('click', changeStaffHandler);
-    changeStaff.addEventListener('click', changeStaffHandler);
-  } catch(e) {console.debug(e);}
+  setEditControls('moreEdit', Contents.defaultSylActionContents);
+  addDeleteListener();
+  addChangeStaffListener();
 }
 
 /**
@@ -930,18 +823,8 @@ export function triggerDefaultSylActions (): void {
  */
 export function triggerDefaultActions (): void {
   endOptionsSelection();
-  try {
-    const moreEdit = document.getElementById('moreEdit');
-    moreEdit.parentElement.classList.remove('hidden');
-    moreEdit.innerHTML = Contents.defaultActionContents;
-  } catch (e) {}
-
-  try {
-    const del = document.getElementById('delete');
-    del.removeEventListener('click', removeHandler);
-    del.addEventListener('click', removeHandler);
-  } catch (e) {}
-  document.body.addEventListener('keydown', deleteButtonHandler);
+  setEditControls('moreEdit', Contents.defaultActionContents);
+  addDeleteListener();
 }
 
 /**

--- a/src/utils/SelectTools.ts
+++ b/src/utils/SelectTools.ts
@@ -423,7 +423,7 @@ export async function selectAll (elements: Array<SVGGraphicsElement>, neonView: 
             Grouping.triggerGrouping('splitSyllable');
           } else if (sharedSecondLevelParent(groups)) {
             Grouping.triggerGrouping('syl');
-            changeStaffListener();
+            SelectOptions.addChangeStaffListener();
           } else {
             // Check if this *could* be a selection with a single logical syllable split by a staff break.
             const staff0 = groups[0].closest('.staff');
@@ -552,12 +552,4 @@ export async function selectAll (elements: Array<SVGGraphicsElement>, neonView: 
     default:
       console.error('Unknown selection type. This should not have occurred.');
   }
-
-  function changeStaffListener(): void {
-    try {
-      document.getElementById('changeStaff')
-        .addEventListener('click', SelectOptions.changeStaffHandler);
-    } catch (e) {console.debug(e);}
-  }
-  
 }


### PR DESCRIPTION
### Changes
Fixes #879 and issue from #862 by refactoring SelectOptions.ts, replacing empty try/catches for explicit null checks or optional chaining.

### Technical Changes
- Use one setEditControls() function to set moreEdit and extraEdit content, so that we do not use empty try/catch's and have to only call ONE function.
- Add addDeleteListener() and addChangeStaffListener() which do null checks instead of try/catch. Replace all try/catches with addDeleteListener() or addChangeStaffListener().
- Add optional chaining for insertToSyllable and moveOuttaSyllable.
- TODO: any event listeners should be removed before a new one is created. Example: insertToSyllable and moveOuttaSyllable addEventListeners.