### PR TITLE
♻️➖ Remove SVGPoint (deprecated) for getSVGRelCoords()

### DIFF
--- a/src/SquareEdit/StaffTools.ts
+++ b/src/SquareEdit/StaffTools.ts
@@ -3,6 +3,7 @@ import NeonView from '../NeonView';
 import { SplitAction } from '../Types';
 import { selectAll } from '../utils/SelectTools';
 import DragHandler from '../utils/DragHandler';
+import { getSVGRelCoords } from '../utils/Coordinates';
 
 /** Handle splitting a staff into two staves through Verovio. */
 export class SplitStaffHandler {
@@ -42,25 +43,15 @@ export class SplitStaffHandler {
 
   /** Handle input to split a staff. */
   handler = ((evt: MouseEvent): void => {
-    const id = this.staff.id;
-
-    const container = this.staff.closest('.definition-scale') as SVGSVGElement;
-    const pt = container.createSVGPoint();
-    pt.x = evt.clientX;
-    pt.y = evt.clientY;
-
-    // Transform to SVG coordinate system.
-    const transformMatrix = (container.getElementsByClassName('system')[0] as SVGGElement)
-      .getScreenCTM().inverse();
-    const cursorPt = pt.matrixTransform(transformMatrix);
     // Find staff point corresponds to if one exists
     // TODO
-
+    const id = this.staff.id;
+    const cursor = getSVGRelCoords(evt.clientX, evt.clientY);
     const editorAction: SplitAction = {
       action: 'split',
       param: {
         elementId: id,
-        x: cursorPt.x
+        x: cursor.x
       }
     };
 
@@ -71,11 +62,13 @@ export class SplitStaffHandler {
       }
       const dragHandler = new DragHandler(this.neonView, '.staff');
       this.splitDisable();
-      selectAll([document.querySelector('#' + id) as SVGGElement], this.neonView, dragHandler);
-      try {
-        document.getElementById('moreEdit').innerHTML = '';
-        document.getElementById('moreEdit').parentElement.classList.add('hidden');
-      } catch (e) {}
+      selectAll([document.querySelector(`#${id}`)], this.neonView, dragHandler);
+
+      const moreEdit = document.getElementById('moreEdit');
+      if (moreEdit) {
+        moreEdit.innerHTML = '';
+        moreEdit.parentElement.classList.add('hidden');
+      }
     });
   }).bind(this);
 

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -48,9 +48,7 @@ export type InsertAction = {
     lrx?: number,
     lry?: number,
     // TODO: attributes are currently never used yet in Neon
-    attributes?: {
-      shape: string
-    }
+    attributes?: { shape: string } | Record<string, string>;
   }
 };
 

--- a/src/utils/Coordinates.ts
+++ b/src/utils/Coordinates.ts
@@ -1,0 +1,56 @@
+import { getStaffBBox } from './SelectTools';
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/**
+ * Get SVG relative coordinates given clientX and clientY
+ * Source: https://stackoverflow.com/questions/29261304
+ */
+export function getSVGRelCoords (clientX: number, clientY: number): Point {
+  const pt = new DOMPoint(clientX, clientY);
+  const svg = document.querySelector<SVGSVGElement>('.active-page > .definition-scale');
+  const system = svg.querySelector<SVGGElement>('.system');
+
+  const { x, y } = pt.matrixTransform(system.getScreenCTM().inverse());
+  return { x, y };
+
+  // If there is some issue with coordinates, this may fix the issue:
+  // const svg = document.querySelector<SVGSVGElement>('#svg_group');
+  // const { x, y } = pt.matrixTransform(svg.getScreenCTM().inverse());
+}
+
+/**
+ * Get ID of staff by client's x-y coordinates.
+ * This function considers the *visual* bounding box of the staff
+ * based on its staff lines, instead of the SVG element itself.
+ */
+export function getStaffIdByCoords (clientX: number, clientY: number): string {
+  const staves = Array.from(document.querySelectorAll<SVGGElement>('.staff'));
+  const staffBBoxes = staves.map(staff => getStaffBBox(staff));
+
+  // find the staff that the cursor is inside
+  const { x, y } = getSVGRelCoords(clientX, clientY);
+  const staff = staffBBoxes.find(
+    (bbox) => x <= bbox.lrx && x >= bbox.ulx && y <= bbox.lry && y >= bbox.uly
+  ); 
+
+  // If there is issues with finding the staff, this may be more accurate:
+  // return (pt.x > ulx && pt.x < lrx) &&
+  //   (pt.y > (uly + (pt.x - ulx) * Math.tan(rotate))) &&
+  //   (pt.y < (lry - (lrx - pt.x) * Math.tan(rotate)));
+
+  // if the cursor is not inside any staff, then explicitly return null
+  return staff ? staff.id : null;
+}
+
+/**
+ * Get staff by client's x-y coordinates; wrapper for getStaffIdByCoords, but
+ *   returns the element, not the ID
+ */
+export function getStaffByCoords (clientX: number, clientY: number): SVGGElement | null {
+  const staffId = getStaffIdByCoords(clientX, clientY);
+  return document.querySelector(`#${staffId}`);
+}

--- a/src/utils/DragHandler.ts
+++ b/src/utils/DragHandler.ts
@@ -1,38 +1,7 @@
 import NeonView from '../NeonView';
 import { ChangeStaffToAction, DragAction, EditorAction } from '../Types';
 import * as d3 from 'd3';
-import { getStaffBBox } from './SelectTools';
-
-/**
- * Get SVG relative coordinates given clientX and clientY
- * Source: https://stackoverflow.com/questions/29261304
- */
-function getSVGRelCoords (clientX: number, clientY: number): [number, number] {
-  const pt = new DOMPoint(clientX, clientY);
-  const svg = document.querySelector<SVGSVGElement>('#svg_group');
-  const { x, y } = pt.matrixTransform(svg.getScreenCTM().inverse());
-
-  return [x, y];
-}
-
-/**
- * Get ID of staff by client's x-y coordinates.
- * This function considers the *visual* bounding box of the staff
- * based on its staff lines, instead of the SVG element itself.
- */
-function getStaff (clientX: number, clientY: number): string {
-  const staves = Array.from(document.querySelectorAll<SVGGElement>('.staff'));
-  const staffBBoxes = staves.map(staff => getStaffBBox(staff));
-
-  // find the staff that the cursor is inside
-  const [x, y] = getSVGRelCoords(clientX, clientY);
-  const staff = staffBBoxes.find(
-    (bbox) => x <= bbox.lrx && x >= bbox.ulx && y <= bbox.lry && y >= bbox.uly
-  ); 
-
-  // if the cursor is not inside any staff, then explicitly return null
-  return staff ? staff.id : null;
-}
+import { getStaffIdByCoords } from './Coordinates';
 
 class DragHandler {
   readonly neonView: NeonView;
@@ -127,7 +96,7 @@ class DragHandler {
 
         if (el.classList.contains('divLine') || el.classList.contains('accid') || el.classList.contains('custos')) {
           const { clientX, clientY } = d3.event.sourceEvent;
-          const newStaff = getStaff(clientX, clientY);
+          const newStaff = getStaffIdByCoords(clientX, clientY);
 
           const staffAction: ChangeStaffToAction = {
             action: 'changeStaffTo',


### PR DESCRIPTION
Fixes #895 by adding a new file called Coordinates.ts with a revamped calculation of SVG-relative coordinates. In my testing, getSVGRelCoords() gives the identical coordinates to what was being calculated before.

Also,
- There are still SVGPoint code in Zoom.ts and Select.ts, which require different calculation than getSVGRelCoords().
- For both getSVGRelCoords() and getStaffIdByCoords(), there is commented out code for an alternative calculation in case that is needed in the future.