### PR TITLE
⚡️ Improve drag selection performance

### DIFF
--- a/src/utils/Select.ts
+++ b/src/utils/Select.ts
@@ -8,7 +8,7 @@ import { InfoInterface } from '../Interfaces';
 import ZoomHandler from '../SingleView/Zoom';
 
 import * as d3 from 'd3';
-import { getStaffByCoords, getSVGRelCoords } from './Coordinates';
+import { getStaffByCoords } from './Coordinates';
 
 let dragHandler: DragHandler, neonView: NeonView, info: InfoInterface, zoomHandler: ZoomHandler;
 let strokeWidth = 7;

--- a/src/utils/SelectTools.ts
+++ b/src/utils/SelectTools.ts
@@ -105,8 +105,12 @@ export function selectLayerElement (layerElement: SVGGElement, dragHandler: Drag
  * Generic select function.
  * @param el - Element to select.
  * @param dragHandler - Only used for staves.
+ * @param needsHighlightUpdate - Whether all the group's highlights should be updated
  */
-export function select (el: SVGGraphicsElement, dragHandler?: DragHandler): void {
+export function select (el: SVGGraphicsElement, dragHandler?: DragHandler, needsHighlightUpdate = true): void {
+  // If element does not exist, exit
+  if (!el) return;
+
   if (el.classList.contains('staff')) {
     return selectStaff(el, dragHandler);
   }
@@ -150,7 +154,9 @@ export function select (el: SVGGraphicsElement, dragHandler?: DragHandler): void
       });
     }
   }
-  updateHighlight();
+
+  if (needsHighlightUpdate)
+    updateHighlight();
 }
 
 /**
@@ -346,9 +352,9 @@ export async function selectAll (elements: Array<SVGGraphicsElement>, neonView: 
 
   // Get the groupings specified by selectionClass
   // that contain the provided elements to select.
-  const groupsToSelect = new Set();
+  const groupsToSelect = new Set<SVGGElement>();
   for (const element of elements) {
-    let grouping = element.closest(selectionClass);
+    let grouping = element.closest<SVGGElement>(selectionClass);
     if (grouping === null) {
       // Check if we click-selected a clef or a custos or an accid or a divLine
       grouping = element.closest('.clef, .custos, .accid, .divLine');
@@ -365,15 +371,15 @@ export async function selectAll (elements: Array<SVGGraphicsElement>, neonView: 
     // Check for precedes/follows
     const follows = grouping.getAttribute('mei:follows');
     if (follows) {
-      groupsToSelect.add(document.getElementById(follows.slice(1)));
+      groupsToSelect.add(document.querySelector('#' + follows.slice(1)));
     }
     const precedes = grouping.getAttribute('mei:precedes');
     if (precedes) {
-      groupsToSelect.add(document.getElementById(precedes.slice(1)));
+      groupsToSelect.add(document.querySelector('#' + precedes.slice(1)));
     }
   }
   // Select the elements
-  groupsToSelect.forEach((group: SVGGraphicsElement) => { select(group, dragHandler); });
+  groupsToSelect.forEach((group: SVGGraphicsElement) => select(group, dragHandler, false));
 
   /* Determine the context menu to display (if any) */
 


### PR DESCRIPTION
Improve performance of drag selection when group highlights are enabled. Drag selecting even a small portion of the folio with group highlights on would freeze Neon for a good second or more. With this fix, time taken is reduced by 99%!

Before:
![Screen Shot 2022-07-13 at 2 08 58 PM](https://user-images.githubusercontent.com/40512164/178828523-ec4201de-c917-44e4-85df-b54ee6ff5e53.png)

https://user-images.githubusercontent.com/40512164/178828738-0dffc35b-1209-407d-b25c-ac382de92913.mov


After:
![Screen Shot 2022-07-13 at 2 09 05 PM](https://user-images.githubusercontent.com/40512164/178828540-ecbccf61-95d1-4b61-8f5f-91eb36a6095c.png)

https://user-images.githubusercontent.com/40512164/178828743-0b776594-1ca3-403e-b9f8-1c3e3c120b17.mov


