### PR TITLE
🚑 Exclude <rect> from OOB check if bboxes are hidden

### DIFF
--- a/src/utils/DragHandler.ts
+++ b/src/utils/DragHandler.ts
@@ -204,8 +204,11 @@ class DragHandler {
    */
   isDragOutOfBounds (selection: SVGGraphicsElement[]): boolean {
     // Get the bounding boxes of all glyphs (<use> elements) within the selection array
+    const isBBoxDisplayed = document.querySelector<HTMLInputElement>('#displayBBox').checked;
+    const glyphSelector = isBBoxDisplayed ? 'use, rect' : 'use';
+
     const glyphs: SVGUseElement[] = selection.reduce(
-      (acc, el) => acc.concat(...el.querySelectorAll('use, rect')), []
+      (acc, el) => acc.concat(...el.querySelectorAll(glyphSelector)), []
     );
     const glyphBBoxes: BBox[] = glyphs.map(getGlyphBBox);
 


### PR DESCRIPTION
Related to #700 ... I made a mistake again when I included <rect>s into OOB calculation, since <rect>s all have x=0,y=0 coordinates when bounding boxes are not displayed. This PR fixes it