### PR TITLE
🐛 Fix non-existent updateSelectedBBox()

### DIFF
--- a/src/TextEditMode.ts
+++ b/src/TextEditMode.ts
@@ -43,6 +43,19 @@ function selBySyllableListener (): void {
   this.addBBoxListeners();
 }
 
+export function updateSelectedBBox (span: HTMLSpanElement, dragHandler: DragHandler, neonView: NeonView) {
+  unselect();
+
+  const bboxId = Array.from(span.classList).find(e => e !== 'text-select' && e !== 'selected-to-edit');
+
+  if ((document.getElementById('displayBBox') as HTMLInputElement).checked) {
+    if (document.getElementById(bboxId)) {
+      const displayRect = document.getElementById(bboxId).querySelector('.sylTextRect-display') as SVGGraphicsElement;
+      selectBBox(displayRect, dragHandler, neonView);
+    }
+  }
+}
+
 /**
  * A Text editing module that works with the SingleView and DivaView modules
  */
@@ -74,7 +87,7 @@ export default class TextEditMode implements TextEditInterface {
         selectBBox(displayRect, this.dragHandler, this.neonView);
       }
     }
-  };
+  }
 
 
   /**
@@ -88,7 +101,7 @@ export default class TextEditMode implements TextEditInterface {
         span.classList.add('selected-to-edit');
         modal.setModalWindowView(ModalWindowView.EDIT_TEXT);
         modal.openModalWindow();
-        this.updateSelectedBBox(span);
+        updateSelectedBBox(span, this.dragHandler, this.neonView);
       }
 
       span.removeEventListener('click', selectSylText);

--- a/src/utils/ModalWindow.ts
+++ b/src/utils/ModalWindow.ts
@@ -3,6 +3,7 @@ import { SetTextAction } from '../Types';
 import { ModalWindowInterface } from '../Interfaces';
 import { hotkeysModal, editTextModal } from '../SquareEdit/Contents';
 import { uploadAreaHTML } from '../Dashboard/dashboard_components';
+import { updateSelectedBBox } from '../TextEditMode';
 
 
 /**
@@ -163,10 +164,10 @@ export class ModalWindow implements ModalWindowInterface {
         document.getElementById('neon-modal-window-header-title').innerText = 'ERROR LOG';
         break;
 
-        case ModalWindowView.DOCUMENT_UPLOAD:
-          document.getElementById('neon-modal-window-header-title').innerText = 'DOCUMENT UPLOAD';
-          document.getElementById('neon-modal-window-content-container').innerHTML = uploadAreaHTML;
-          break;
+      case ModalWindowView.DOCUMENT_UPLOAD:
+        document.getElementById('neon-modal-window-header-title').innerText = 'DOCUMENT UPLOAD';
+        document.getElementById('neon-modal-window-content-container').innerHTML = uploadAreaHTML;
+        break;
 
       default:
         console.error('Unknown selection type. This should not have occurred.');
@@ -199,8 +200,6 @@ export class ModalWindow implements ModalWindowInterface {
     this.focusModalWindow();
   };
 
-
-
   /**
    * Update text of selected-to-edit syllables with user-provided text
    */
@@ -229,7 +228,7 @@ export class ModalWindow implements ModalWindowInterface {
             // An update to the page will reload the entire svg;
             // We would like to then reselect the same selected syllable
             // if bboxes are enabled
-            this.updateSelectedBBox(span);
+            updateSelectedBBox(span, this.dragHandler, this.neonView);
           });
         }
       });


### PR DESCRIPTION
There was an error with updateSelectedBBox() which would be called any time the user edits the syl text of a bounding box. This issue seemed to have been due to some misorganization and perhaps discarded during a hasty merge of a pull request.

Anyways, it has been extracted into its own method which can be called from both TextEditMode.ts and ModalWindow.ts