### PR TITLE
✨ Re-introduce feature that allows grouping of certain non-adjacent neumes.

### DIFF
--- a/src/utils/SelectTools.ts
+++ b/src/utils/SelectTools.ts
@@ -222,8 +222,12 @@ export function areAdjacent(selectionType: string, elements: SVGGraphicsElement[
       break;
 
     case 'selByNeume':
-      allElemsOfSelectionType = Array.from(document.querySelectorAll('.neume'));
-      break;
+      // We automatically return 'true' for neumes because we want the user to be 
+      // allowed to group two neumes in separate syllabes without having to parform other
+      // steps first. Yes, there is a trade-off - this allows users to try and group any 
+      // two non-adjacent neumes, but it was decided that the benefits (speed and efficiency)
+      // outweigh the costs (user trying an illegal edit).
+      return true;
 
     case 'selByNc':
       allElemsOfSelectionType = Array.from(document.querySelectorAll('.nc'));


### PR DESCRIPTION
Fixes #966 

Users are now able to group neumes that appear to be adjacent visually, but may not be represented that way in the MEI file.